### PR TITLE
Closes #1 Missing slope attribute

### DIFF
--- a/lib/vendor/enshrined/svg-sanitize/src/data/AllowedAttributes.php
+++ b/lib/vendor/enshrined/svg-sanitize/src/data/AllowedAttributes.php
@@ -224,6 +224,7 @@ class AllowedAttributes implements AttributeInterface
             'scale',
             'seed',
             'shape-rendering',
+            'slope',
             'specularconstant',
             'specularexponent',
             'spreadmethod',


### PR DESCRIPTION
The slope attribute is missing from the allowed attributes in the XML sanitizer library.