### PR TITLE
Only attempt to parse dimensions if numeric

### DIFF
--- a/safe-svg.php
+++ b/safe-svg.php
@@ -426,7 +426,7 @@ if ( ! class_exists( 'safe_svg' ) ) {
             $height = 0;
             if ( $svg ) {
                 $attributes = $svg->attributes();
-                if ( isset( $attributes->width, $attributes->height ) ) {
+                if ( isset( $attributes->width, $attributes->height ) && is_numeric( $attributes->width ) && is_numeric( $attributes->height ) ) {
                     $width  = floatval( $attributes->width );
                     $height = floatval( $attributes->height );
                 } elseif ( isset( $attributes->viewBox ) ) {


### PR DESCRIPTION
Currently images uploaded with `width="100%"` attributes will get parsed as `100`, so the dimentions are incorrect. Given the following image:

```
<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:serif="http://www.serif.com/" width="100%" height="100%" viewBox="0 0 500 250"
```

Will result in an image which is `100 x 100`, but we actually want it to be parsed as `500 x 250`.