### PR TITLE
PHP 8.0: libxml_disable_entity_loader function is deprecated

### DIFF
--- a/lib/vendor/enshrined/svg-sanitize/src/Sanitizer.php
+++ b/lib/vendor/enshrined/svg-sanitize/src/Sanitizer.php
@@ -245,8 +245,11 @@ class Sanitizer
      */
     protected function setUpBefore()
     {
-        // Turn off the entity loader
-        $this->xmlLoaderValue = libxml_disable_entity_loader(true);
+        
+        if (\PHP_VERSION_ID < 80000 && \LIBXML_VERSION < 20900) {
+            // Turn off the entity loader
+            $this->xmlLoaderValue = libxml_disable_entity_loader(true);
+        }
 
         // Suppress the errors because we don't really have to worry about formation before cleansing
         libxml_use_internal_errors(true);
@@ -260,8 +263,10 @@ class Sanitizer
      */
     protected function resetAfter()
     {
-        // Reset the entity loader
-        libxml_disable_entity_loader($this->xmlLoaderValue);
+        if (\PHP_VERSION_ID < 80000 && \LIBXML_VERSION < 20900) {
+            // Reset the entity loader
+            libxml_disable_entity_loader($this->xmlLoaderValue);
+        }
     }
 
     /**


### PR DESCRIPTION
commit checks PHP and LIBXML_VERSION before calling libxml_disable_entity_loader.

Feel free to noodle how you see fit. I was getting a fatal error on my Kinsta install, so I had to make the change anyway. See https://php.watch/versions/8.0/libxml_disable_entity_loader-deprecation for further insight.