### PR TITLE
bump WP tested-up-to version 5.8

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,13 +1,13 @@
 === Safe SVG ===
-Contributors: enshrined
-Donate link: https://wpsvg.com/
-Tags: svg, sanitize, upload, sanitise, security, svg upload, image, vector, file, graphic, media, mime
+Contributors:      enshrined
+Donate link:       https://wpsvg.com/
+Tags:              svg, sanitize, upload, sanitise, security, svg upload, image, vector, file, graphic, media, mime
 Requires at least: 4.0
-Tested up to: 5.4.1
-Requires PHP: 5.6
-Stable tag: 1.9.9
-License: GPLv2 or later
-License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Tested up to:      5.8
+Requires PHP:      5.6
+Stable tag:        1.9.9
+License:           GPLv2 or later
+License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 
 Enable SVG uploads and sanitize them to stop XML/SVG vulnerabilities in your WordPress website
 


### PR DESCRIPTION
Co-Authored-By: BBerg10up <72762903+BBerg10up@users.noreply.github.com>

<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

After @BBerg10up's testing in #13, this PR bumps the "tested up to" version 5.8.

### Alternate Designs

n/a

### Benefits

Ensures the plugin properly states its latest tested version on WP.org.

### Possible Drawbacks

none identified

### Verification Process

@BBerg10up tested in https://github.com/10up/safe-svg/issues/13#issuecomment-944996947.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Closes #13.

### Changelog Entry

```
### Changed
- Bump WordPress version "tested up to" 5.8 (props @BBerg10up).
```
