### PR TITLE
Bug fixes relating to image dimensions

### DIFF
--- a/safe-svg.php
+++ b/safe-svg.php
@@ -327,7 +327,7 @@ if ( ! class_exists( 'safe_svg' ) ) {
                 $svg_path               = get_attached_file( $attachment_id );
                 $upload_dir             = wp_upload_dir();
                 // get the path relative to /uploads/ - found no better way:
-                $relative_path = str_replace( $upload_dir['basedir'], '', $svg_path );
+                $relative_path = str_replace( trailingslashit( $upload_dir['basedir'] ), '', $svg_path );
                 $filename      = basename( $svg_path );
 
                 $dimensions = $this->svg_dimensions( $svg_path );

--- a/safe-svg.php
+++ b/safe-svg.php
@@ -49,7 +49,6 @@ if ( ! class_exists( 'safe_svg' ) ) {
             add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'add_upgrade_link' ) );
             add_filter( 'wp_get_attachment_metadata', array( $this, 'metadata_error_fix' ), 10, 2 );
             add_filter( 'wp_get_attachment_image_attributes', array( $this, 'fix_direct_image_output' ), 10, 3 );
-			add_filter( 'wp_calculate_image_srcset_meta', array( $this, 'fix_svg_image_meta' ), 10 );
         }
 
         /**
@@ -482,21 +481,6 @@ if ( ! class_exists( 'safe_svg' ) ) {
 
             return $attr;
         }
-
-	    /**
-	     * Fix svg file path in attachment meta for old uploads.
-	     *
-	     * @param array $image_meta Attachment meta.
-	     *
-	     * @return array Attachment meta.
-	     */
-		public function fix_svg_image_meta( $image_meta ) {
-			if ( ! empty( $image_meta['file'] ) && '.svg' === substr( $image_meta['file'], -4 ) && false !== strpos( $image_meta['file'], '/', 1 ) ) {
-				$image_meta['file'] = substr( $image_meta['file'], 1 );
-			}
-			return $image_meta;
-		}
-
     }
 }
 

--- a/safe-svg.php
+++ b/safe-svg.php
@@ -49,6 +49,7 @@ if ( ! class_exists( 'safe_svg' ) ) {
             add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'add_upgrade_link' ) );
             add_filter( 'wp_get_attachment_metadata', array( $this, 'metadata_error_fix' ), 10, 2 );
             add_filter( 'wp_get_attachment_image_attributes', array( $this, 'fix_direct_image_output' ), 10, 3 );
+			add_filter( 'wp_calculate_image_srcset_meta', array( $this, 'fix_svg_image_meta' ), 10 );
         }
 
         /**
@@ -481,6 +482,20 @@ if ( ! class_exists( 'safe_svg' ) ) {
 
             return $attr;
         }
+
+	    /**
+	     * Fix svg file path in attachment meta for old uploads.
+	     *
+	     * @param array $image_meta Attachment meta.
+	     *
+	     * @return array Attachment meta.
+	     */
+		public function fix_svg_image_meta( $image_meta ) {
+			if ( ! empty( $image_meta['file'] ) && '.svg' === substr( $image_meta['file'], -4 ) && false !== strpos( $image_meta['file'], '/', 1 ) ) {
+				$image_meta['file'] = substr( $image_meta['file'], 1 );
+			}
+			return $image_meta;
+		}
 
     }
 }

--- a/safe-svg.php
+++ b/safe-svg.php
@@ -427,7 +427,7 @@ if ( ! class_exists( 'safe_svg' ) ) {
             $height = 0;
             if ( $svg ) {
                 $attributes = $svg->attributes();
-                if ( isset( $attributes->width, $attributes->height ) && is_numeric( $attributes->width ) && is_numeric( $attributes->height ) ) {
+                if ( isset( $attributes->width, $attributes->height ) && is_numeric( (float)$attributes->width ) && is_numeric( (float)$attributes->height ) ) {
                     $width  = floatval( $attributes->width );
                     $height = floatval( $attributes->height );
                 } elseif ( isset( $attributes->viewBox ) ) {


### PR DESCRIPTION
### Requirements

- Remove double slashes in the file url when rendered
- A missing string cast causes dimensions to be lost from some SVGs.
- A bug with srcsets breaks square SVGs entirely in Chrome. - We will not fix it as it crosses with WP.


### Description of the Change

- For newer uploads we have fixed the double slash being added in svg file url
- Float value casting fix for svgs when fetching width and height.

### Alternate Designs

No alternate designs.

### Benefits

- SVG uploaded without viewbox will be rendered properly on front end.

### Possible Drawbacks

No drawback.

### Verification Process

- Upload SVG in Media and see that attachment meta has now proper file path which should be `2022/01/FILENAME.svg`
- Float cast of width and height when fetching svg sizes gives correct width and height when rendering.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#15 

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
