### PR TITLE
Ensure we keep proper height and width settings for SVGs, unless those values don't exist

### DIFF
--- a/safe-svg.php
+++ b/safe-svg.php
@@ -225,7 +225,7 @@ if ( ! class_exists( 'safe_svg' ) ) {
 
         /**
          * Filters the image src result.
-         * Here we're gonna spoof the image size and set it to 100 width and height
+         * If the image size doesn't exist, set a default size off 100 for width and height
          *
          * @param array|false $image Either array with src, width & height, icon src, or false.
          * @param int $attachment_id Image attachment ID.
@@ -236,9 +236,14 @@ if ( ! class_exists( 'safe_svg' ) ) {
          * @return array
          */
         public function one_pixel_fix( $image, $attachment_id, $size, $icon ) {
-            if ( get_post_mime_type( $attachment_id ) == 'image/svg+xml' ) {
-                $image['1'] = false;
-                $image['2'] = false;
+            if ( get_post_mime_type( $attachment_id ) === 'image/svg+xml' ) {
+                if ( empty( $image[1] ) ) {
+                    $image[1] = 100;
+                }
+
+                if ( empty( $image[2] ) ) {
+                    $image[2] = 100;
+                }
             }
 
             return $image;

--- a/safe-svg.php
+++ b/safe-svg.php
@@ -225,7 +225,7 @@ if ( ! class_exists( 'safe_svg' ) ) {
 
         /**
          * Filters the image src result.
-         * If the image size doesn't exist, set a default size off 100 for width and height
+         * If the image size doesn't exist, set a default size of 100 for width and height
          *
          * @param array|false $image Either array with src, width & height, icon src, or false.
          * @param int $attachment_id Image attachment ID.


### PR DESCRIPTION
### Description of the Change

Previously we were setting the height and width of SVGs to be `false`, which can cause issues in certain places (like within Gutenberg) if they use those values for calculations. Instead, use the height and width values WordPress calculates for those files and if they don't exist for some reason, default those to 100, so we have a proper fallback value.

Closes #18 

### Alternate Designs

None

### Possible Drawbacks

I'm unsure of why we were setting these to `false` to begin with. The function documentation even mentions we default to 100, but as far as I can tell, that was never happening. I've tested a number of various scenarios and I've not seen any issues with using the calculated height and width instead of using `false` but there's potential that I missed some scenario.
 
### Verification Process

Follow the reproduction steps listed in #18 to verify the reported issue.

In addition, ensure that any SVG that gets uploaded displays correctly within the admin Media Library, within the attachment single page and when added to a Post or Page.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

> Fixed - Use calculated size for SVGs instead of using `false`

### Credits

