### PR TITLE
Better checking of the file type when determining which files are SVGs

### DIFF
--- a/safe-svg.php
+++ b/safe-svg.php
@@ -105,7 +105,10 @@ if ( ! class_exists( 'safe_svg' ) ) {
          */
         public function check_for_svg( $file ) {
 
-            if ( $file['type'] === 'image/svg+xml' ) {
+            $wp_filetype = wp_check_filetype_and_ext( $file['tmp_name'], $file['name'] );
+            $type        = ! empty( $wp_filetype['type'] ) ? $wp_filetype['type'] : '';
+
+            if ( $type === 'image/svg+xml' ) {
                 if ( ! $this->sanitize( $file['tmp_name'] ) ) {
                     $file['error'] = __( "Sorry, this file couldn't be sanitized so for security reasons wasn't uploaded",
                         'safe-svg' );


### PR DESCRIPTION
### Description of the Change

We currently have a function that is hooked into the `wp_handle_upload_prefilter` filter. In there we check if the file type is `image/svg+xml` and if so, we sanitize the file. If that sanitization process fails, we don't allow the file to be uploaded to WordPress.

There's a potential issue here though because the file type we rely on comes from the `Content-Type` of the original `form-data` request. Typically this will be automatically set to whatever the real file type is but in theory, someone could spoof this request and set `Content-Type` to be anything, like `image/png`. In this case, they could send an actual SVG in the `form-data` but set the `Content-Type` to be `image/png`, which would then bypass our sanitization process (but would still be uploaded to WordPress).

This PR fixes this by utilizing the core WordPress function `wp_check_filetype_and_ext` to get the file type, instead of relying on the value that comes from the request. This should still work in all legitimate cases and if someone were to try sending a proper SVG but they change the `Content-Type` in the request, it will also catch that.

I tested the following scenarios:
- Valid SVG uploaded without a custom `Content-Type` set. **Our sanitization kicks in** ✅ 
- Valid SVG uploaded with a custom `Content-Type` set (set to `image/png`). **Our sanitization kicks in** ✅ 
- Valid PNG uploaded without a custom `Content-Type` set. **No sanitization needed from us** ✅ 
- SVG file with a .png extension uploaded without a custom `Content-Type` set. **File rejected** ✅ 
- SVG file with a .png extension uploaded with a custom `Content-Type` set. **File rejected** ✅ 
- SVG file with no extension uploaded without a custom `Content-Type` set. **File rejected** ✅ 
- SVG file with no extension uploaded with a custom `Content-Type` set. **File rejected** ✅ 

### Alternate Designs

None

### Possible Drawbacks

Slight impact on performance but should be minimal

### Verification Process

Ensure that you can still properly upload SVGs in WordPress.

If desired, can also manually make a `curl` request to send an SVG with a manipulated `Content-Type` field, to verify that captures things correctly. I can provide an example `curl` command if needed.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

> Fixed - add better file type checking when looking for SVG files