### PR TITLE
Ensure composer commands work on PHP 7+, not just PHP 7.*+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"require": {
-		"php": "^7.0",
+		"php": ">=7.0",
 		"enshrined/svg-sanitize": "^0.15.2"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "25644808f5aef14ac756e6a8a0159c3e",
+    "content-hash": "9d1ff5348c8ca13a8c11ebc9cd72fe3d",
     "packages": [
         {
             "name": "enshrined/svg-sanitize",
@@ -59,8 +59,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.0"
+        "php": ">=7.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
### Description of the Change

Our `composer.json` was locked to the PHP 7 line, so running commands like `composer install` would not work on PHP 8 environments (this was causing an issue in our release workflow). This PR changes the PHP requirement to be PHP 7+, which supports PHP 7 and PHP 8.

### Alternate Designs

In our release workflow, we could add code to switch to PHP 7 so our command works. But would still break for those developing locally using PHP 8.

### Possible Drawbacks

None

### Verification Process

Ensure `composer install` works if you are running PHP 8+

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.
