### PR TITLE
Disable the creation of srcset on SVGs

### DIFF
--- a/safe-svg.php
+++ b/safe-svg.php
@@ -79,6 +79,7 @@ if ( ! class_exists( 'safe_svg' ) ) {
             add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'add_upgrade_link' ) );
             add_filter( 'wp_get_attachment_metadata', array( $this, 'metadata_error_fix' ), 10, 2 );
             add_filter( 'wp_get_attachment_image_attributes', array( $this, 'fix_direct_image_output' ), 10, 3 );
+            add_filter( 'wp_calculate_image_srcset_meta', array( $this, 'disable_srcset' ), 10, 4 );
         }
 
         /**
@@ -519,6 +520,28 @@ if ( ! class_exists( 'safe_svg' ) ) {
 
             return $attr;
         }
+
+        /**
+         * Disable the creation of srcset on SVG images.
+         *
+         * @param array $image_meta The image meta data.
+         * @param int[]  $size_array    {
+         *     An array of requested width and height values.
+         *
+         *     @type int $0 The width in pixels.
+         *     @type int $1 The height in pixels.
+         * }
+         * @param string $image_src     The 'src' of the image.
+         * @param int    $attachment_id The image attachment ID.
+         */
+        public function disable_srcset( $image_meta, $size_array, $image_src, $attachment_id ) {
+            if ( $attachment_id && 'image/svg+xml' === get_post_mime_type( $attachment_id ) ) {
+                $image_meta['sizes'] = array();
+            }
+
+            return $image_meta;
+        }
+
     }
 }
 


### PR DESCRIPTION
### Description of the Change

In #23 we changed some behavior on how the height and width of SVGs are set. Previously those values were set to `false`, which in some instances just gets translated to zero. But this caused some issues in a few places, like the block editor, as technically those values are supposed to be integers and if those aren't converted to integers, it will cause PHP errors. We fixed this by using the actual height and width of the SVG and if those don't exist, we default to 100.

We've had a few reports though of where SVGs are now showing up larger than expected. I've only been able to reproduce this issue if directly using `wp_get_attachment_image` to output an SVG, though curiously I'm getting the wrong size images on the previous release as well. It seems the bug with the new release has to do with adding `srcset` to these images, whereas previously those weren't being added as we were overriding height and width to be `false`. I don't think we need `srcset`, so this PR removes that from all SVGs.

On the previous release, if using `wp_get_attachment_image` and not setting a size (so defaulting to thumbnail) I get this markup:
```
<img src="http://oss.local/wp-content/uploads/2022/02/kiwi-2.svg" class="attachment-thumbnail size-thumbnail" alt="" loading="lazy" height="502.174" width="612">
```
This is incorrect as I should be getting an image that is 150x150, so I get a larger than expected image.

Using the same settings on the newest release:
```
<img width="150" height="150" src="http://oss.local/wp-content/uploads/2022/02/kiwi-2.svg" class="attachment-thumbnail size-thumbnail" alt="" loading="lazy" srcset="http://oss.local/wp-content/uploads/2022/02/kiwi-2.svg 150w, http://oss.local/wp-content/uploads/2022/02/kiwi-2.svg 300w, http://oss.local/wp-content/uploads/2022/02/kiwi-2.svg 1024w, http://oss.local/wp-content/uploads/2022/02/kiwi-2.svg 1536w, http://oss.local/wp-content/uploads/2022/02/kiwi-2.svg 2048w" sizes="(max-width: 150px) 100vw, 150px">
```
This gives me the right height and width set but because of the `srcset`, I can potentially get a larger or smaller image on various breakpoints.

After the changes in this PR:
```
<img width="150" height="150" src="http://oss.local/wp-content/uploads/2022/02/kiwi-2.svg" class="attachment-thumbnail size-thumbnail" alt="" loading="lazy">
```

Right height and width but no more `srcset` or `sizes`.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

> Fixed - Remove `srcset` and `sizes` from SVG image output