### PR TITLE
Revert changes made in #19 and #23

### DIFF
--- a/safe-svg.php
+++ b/safe-svg.php
@@ -257,8 +257,7 @@ if ( ! class_exists( 'safe_svg' ) ) {
         }
 
         /**
-         * Filters the image src result.
-         * If the image size doesn't exist, set a default size of 100 for width and height
+         * Filters the image size results.
          *
          * @param array|false $image Either array with src, width & height, icon src, or false.
          * @param int $attachment_id Image attachment ID.
@@ -270,13 +269,8 @@ if ( ! class_exists( 'safe_svg' ) ) {
          */
         public function one_pixel_fix( $image, $attachment_id, $size, $icon ) {
             if ( get_post_mime_type( $attachment_id ) === 'image/svg+xml' ) {
-                if ( empty( $image[1] ) ) {
-                    $image[1] = 100;
-                }
-
-                if ( empty( $image[2] ) ) {
-                    $image[2] = 100;
-                }
+                $image['1'] = false;
+                $image['2'] = false;
             }
 
             return $image;
@@ -464,7 +458,7 @@ if ( ! class_exists( 'safe_svg' ) ) {
             $height = 0;
             if ( $svg ) {
                 $attributes = $svg->attributes();
-                if ( isset( $attributes->width, $attributes->height ) && is_numeric( (float)$attributes->width ) && is_numeric( (float)$attributes->height ) ) {
+                if ( isset( $attributes->width, $attributes->height ) && is_numeric( $attributes->width ) && is_numeric( $attributes->height ) ) {
                     $width  = floatval( $attributes->width );
                     $height = floatval( $attributes->height );
                 } elseif ( isset( $attributes->viewBox ) ) {


### PR DESCRIPTION
### Description of the Change

In PR #19, we fixed a bug around calculating the height and width of an SVG to properly use the `height` and `width` attributes and then fallback to the `viewbox` attribute. This was definitely a bug that was good to fix but the issue here is for any previously uploaded SVGs that had different dimensions in the `height` and `width` attributes as compared to the`viewbox` attribute, this can cause wrong image dimensions to now be used.

For instance, if an SVG had a viewbox of `0 0 32 32` and a `width` of 200 and `height` of 200, even though we look at `height` and `width` first, because of the bug, those values were never used and instead, 32x32 would be used as the SVG dimensions (and stored as image meta). With the bug fix introduced in #19, we now properly use the `height` and `width` attributes but in this example, we still have 32x32 stored, so we end up with two different image dimensions. This can cause the SVG to be either too big or too small and we also output two separate `height` and `width` attributes on the resulting `<img>` tag. This PR reverts that particular change. This does re-introduce the originally reported bug, which we'll need to still solve.

In PR #23, we fixed a bug around overriding the height and width values of an image to be `false`, when those values are expected to be of the type integer. This was causing an issue with certain aspects of Full Site Editing (the logo block in particular) and could potentially cause issues elsewhere. This is again a legitimate bug that should be fixed but this introduced some issues.

In particular, if directly using `wp_get_attachment_image`, the size requested will now be used for the image tag, instead of the actual size of the SVG. As an example, an SVG with dimensions of 30x30 but a requested image size of medium (default to 300x300), 300x300 will be used on the resulting `<img>` tag, making that SVG larger than expected. This PR reverts that change and thus brings back the original issue but resolves backwards compatibility. 

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

> Fixed - Reverted fix to properly use the SVG `height` and `width` attributes, not just `viewbox`. Reverted fix around using the proper image dimensions instead of `false` 