### PR TITLE
Ensure we have a proper file path and file name before we use them

### DIFF
--- a/safe-svg.php
+++ b/safe-svg.php
@@ -133,7 +133,13 @@ if ( ! class_exists( 'safe_svg' ) ) {
          */
         public function check_for_svg( $file ) {
 
-            $wp_filetype = wp_check_filetype_and_ext( $file['tmp_name'], $file['name'] );
+            // Ensure we have a proper file path before processing
+            if ( ! isset( $file['tmp_name'] ) ) {
+                return $file;
+            }
+
+            $file_name   = isset( $file['name'] ) ? $file['name'] : '';
+            $wp_filetype = wp_check_filetype_and_ext( $file['tmp_name'], $file_name );
             $type        = ! empty( $wp_filetype['type'] ) ? $wp_filetype['type'] : '';
 
             if ( $type === 'image/svg+xml' ) {


### PR DESCRIPTION
### Description of the Change

As reported in #45, if for some reason a file `tmp_name` (the temporary location of the uploaded file) or file `name` (the actual file name) doesn't exist in the file array, a PHP error can be generated because we are accessing an undefined variable. This shouldn't be a common scenario (because if the `tmp_name` doesn't exist, that means the file wasn't uploaded properly) but is something we should try catching.

This PR fixes this be ensuring both the file `tmp_name` and file `name` exist before we use those.

Closes #45

### Possible Drawbacks

None

### Verification Process

I was not able to reproduce this myself but the scenario is you somehow upload a file but the upload fails and yet things still keep processing.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

> Fixed - Ensure the `tmp_name` and `name` properties exist before we use them

### Credits

Props @aksld
