### PR TITLE
Ensure our width and height variables exist before we use them

### DIFF
--- a/safe-svg.php
+++ b/safe-svg.php
@@ -500,12 +500,24 @@ if ( ! class_exists( 'safe_svg' ) ) {
                  *
                  * @return {bool} If we should use the width & height attributes first or not.
                  */
-                if ( (bool) apply_filters( 'safe_svg_use_width_height_attributes', false, $svg ) ) {
-                    $width  = $attr_width ?? 0;
-                    $height = $attr_height ?? 0;
+                $use_width_height = (bool) apply_filters( 'safe_svg_use_width_height_attributes', false, $svg );
+
+                if ( $use_width_height ) {
+                    if ( isset( $attr_width, $attr_height ) ) {
+                        $width  = $attr_width;
+                        $height = $attr_height;
+                    } elseif ( isset( $viewbox_width, $viewbox_height ) ) {
+                        $width  = $viewbox_width;
+                        $height = $viewbox_height;
+                    }
                 } else {
-                    $width  = $viewbox_width ?? 0;
-                    $height = $viewbox_height ?? 0;
+                    if ( isset( $viewbox_width, $viewbox_height ) ) {
+                        $width  = $viewbox_width;
+                        $height = $viewbox_height;
+                    } elseif ( isset( $attr_width, $attr_height ) ) {
+                        $width  = $attr_width;
+                        $height = $attr_height;
+                    }
                 }
 
                 if ( ! $width && ! $height ) {

--- a/safe-svg.php
+++ b/safe-svg.php
@@ -501,11 +501,11 @@ if ( ! class_exists( 'safe_svg' ) ) {
                  * @return {bool} If we should use the width & height attributes first or not.
                  */
                 if ( (bool) apply_filters( 'safe_svg_use_width_height_attributes', false, $svg ) ) {
-                    $width  = $attr_width;
-                    $height = $attr_height;
+                    $width  = $attr_width ?? 0;
+                    $height = $attr_height ?? 0;
                 } else {
-                    $width  = $viewbox_width;
-                    $height = $viewbox_height;
+                    $width  = $viewbox_width ?? 0;
+                    $height = $viewbox_height ?? 0;
                 }
 
                 if ( ! $width && ! $height ) {


### PR DESCRIPTION
### Description of the Change

In #43 we slightly changed up how we determine the dimensions of an SVG image, to fix a previous bug but to also preserve backwards compat. There's a minor bug in the fix though, where if an SVG doesn't have the `viewbox` attribute set or doesn't have the `height` and `width` attributes set and a site is using the newly introduced filter, a PHP warning will be output because we try and use a variable that isn't defined.

This PR fixes that by ensuring the attributes we want are set before we use them. We also add better fallback handling so if, for instance, `viewbox` attributes aren't set we still try to use the `height` and `width` attributes (and vice versa, if the new filter is used).

### Alternate Designs

None

### Possible Drawbacks

None

### Verification Process

Prior to this fix, test rendering an SVG that doesn't have the `viewbox` attribute set and notice PHP warnings are displayed (assuming you have debug turned on).

After this fix, those warnings should go away.

In either case, the actual SVG output should be the same.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

> Fixed - Ensure our height and width attributes are set before using them


### Credits

Props @dkotter, @r8r
