### PR TITLE
Remove CSS fix that is no longer needed

### DIFF
--- a/assets/safe-svg.css
+++ b/assets/safe-svg.css
@@ -4,10 +4,3 @@
 #postimagediv .inside .svg img {
     width: 100%;
 }
-
-/**
- * Fix for Gutenberg not showing featured images correctly.
- */
-img.components-responsive-wrapper__content[src$=".svg"] {
-    position: relative;
-}


### PR DESCRIPTION
### Description of the Change

As described in #62, there's some unnecessary spacing being added to the display of featured images in the admin, when an svg is used. This is because of a line of CSS we were adding. This PR removes that CSS.
 
I wanted to trace the history of that to ensure we could safely remove that. It seems that was added in the [v1.8.1 release](https://github.com/10up/safe-svg/commit/770998d0ab7531b131207dd0e39fe1bf66d667f0#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R67) (Nov 2018) and was mentioned to be a fix for the featured image display in Gutenberg. Looking further, the issue was reported on the [.org forums](https://wordpress.org/support/topic/svgs-in-gutenberg-editor/) just a week or so before that.

After removing that CSS, I checked a WP 5.0 environment and could not replicate the original reported issue. I'm assuming this was fixed in Gutenberg prior to the WP 5.0 release (which was only a month or so after this fix was added to Safe SVG). So as far as I can tell, we are safe to remove this. 

Closes #62

### Note

While testing this, I was able to reproduce another scenario where extra spacing was being added to the featured image display in the admin. Diving into the code that Gutenberg uses to render this, I found there's a [Responsive Wrapper component](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/responsive-wrapper/index.js) that adds a span tag above the featured image tag and adds an inline padding-bottom to that. This padding is based on the height and width of the featured image.

In the version of Gutenberg that shipped with WP 6.0, we default to the `post-thumbnail` image size, if that exists. In the most recent version of the Gutenberg plugin (and what I assume will ship in WP 6.1) we now default to the [`large` image size](https://github.com/WordPress/gutenberg/pull/40126/files#diff-9b8c234ca3c82c5dcc1841899d5825553a4fd559b4c7d03c96a827b0ecbff314R58).

I'm running the Twenty Twenty One theme locally and it has a `post-thumbail` size set to [1568x9999](https://github.com/WordPress/twentytwentyone/blob/trunk/functions.php#L72). When using a size of 9999, WordPress is supposed to use the other dimension first and then scale the second appropriately. When an SVG is uploaded, Safe SVG tries to store the proper image sizes in meta (without actually generating re-sized images) and so we end up storing the size 1568x9999 (since SVGs can scale infinitely).

This ends up being the image dimensions that are used for the padding calculation mentioned above and results in something like 600%+ bottom padding being added. If I switch to the latest version of the Gutenberg plugin (and thus it now uses the `large` image size), the bottom padding is calculated correctly.

I think ultimately this is another bug we probably should look to fix here, that when a site has an image size registered to be 9999, instead of just using that as-is, we should try and figure out the scaled dimensions to use instead. Probably not a big deal to fix but mentioning here as other's may run into the same issue I saw where extra spacing is still being added even after this fix.

### Alternate Designs

None

### Possible Drawbacks

Potential to introduce a regression that this line of CSS was added to solve in the first place. I couldn't replicate any problems myself though

### Verification Process

1. Add an SVG as a featured image to a post
2. Verify there isn't extra spacing being added

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

> Removed - unneeded admin CSS fix


### Credits

Props @AdamWills, @dkotter
