### PR TITLE
Bump WordPress tested up to version 6.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      10up, enshrined
 Tags:              svg, sanitize, upload, sanitise, security, svg upload, image, vector, file, graphic, media, mime
 Requires at least: 4.7
-Tested up to:      5.9
+Tested up to:      6.0
 Stable tag:        2.0.1
 Requires PHP:      7.0
 License:           GPLv2 or later


### PR DESCRIPTION
### Description of the Change

Bump our `Tested up to` version to WP 6.0.

Closes #55 

### Alternate Designs

None.

### Possible Drawbacks

None.

### Verification Process

Tested the following scenarios in a WP 6.0 environment:

- [x] Uploading an SVG from the Media Library > Add New page
- [x] Uploading an SVG from the drag and drop uploader
- [x] Viewing an SVG's single attachment edit screen
- [x] Viewing an SVG's single attachment overlay edit screen
- [x] Adding an SVG to the Image block (both uploading directly and pulling from the Media Library)
- [x] Using an SVG as a featured image
- [x] Outputting an SVG directly using `get_image_tag`
- [x] Outputting an SVG directly using `wp_get_attachment_image`

### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry

> Changed - Bump WordPress version "tested up to" 6.0

### Credits

Props @dkotter
