### PR TITLE
Bump minimum PHP and WP versions.

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#5.2'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#5.7'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
 
     steps:

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   php_compatibility:
-    name: PHP minimum 7.0
+    name: PHP minimum 7.4
     runs-on: ubuntu-latest
 
     steps:
@@ -29,4 +29,4 @@ jobs:
         run: composer install
 
       - name: Run PHP Compatibility
-        run: vendor/bin/phpcs *.php includes -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.0-
+        run: vendor/bin/phpcs *.php includes -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.4-

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -20,8 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # We claim to support from 5.6+ but WP Mock only supports 7.1+
-        php: [ '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        php: [ '7.4', '8.0', '8.1' ]
         os: [ ubuntu-latest ]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ SVG Sanitization is done through the following library: [https://github.com/dary
 
 ## Requirements
 
-* PHP 7.0+
-* [WordPress](http://wordpress.org/) 4.0+
+* PHP 7.4+
+* [WordPress](http://wordpress.org/) 5.7+
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		}
 	],
 	"require": {
-		"php": ">=7.0",
+		"php": ">=7.4",
 		"enshrined/svg-sanitize": "^0.15.2"
 	},
 	"require-dev": {
@@ -31,7 +31,7 @@
 	"scripts": {
 		"phpcs": "./vendor/bin/phpcs . -p -s",
 		"phpcbf": "./vendor/bin/phpcbf .",
-		"phpcs:compat": "./vendor/bin/phpcs *.php includes -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.0-",
+		"phpcs:compat": "./vendor/bin/phpcs *.php includes -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.4-",
 		"test:unit": "./vendor/bin/phpunit"
 	},
 	"config": {

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Safe SVG ===
 Contributors:      10up, enshrined
 Tags:              svg, sanitize, upload, sanitise, security, svg upload, image, vector, file, graphic, media, mime
-Requires at least: 4.7
+Requires at least: 5.7
 Tested up to:      6.0
 Stable tag:        2.0.3
-Requires PHP:      7.0
+Requires PHP:      7.4
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/safe-svg.php
+++ b/safe-svg.php
@@ -4,8 +4,8 @@
  * Plugin URI:        https://wordpress.org/plugins/safe-svg/
  * Description:       Enable SVG uploads and sanitize them to stop XML/SVG vulnerabilities in your WordPress website
  * Version:           2.0.3
- * Requires at least: 4.7
- * Requires PHP:      7.0
+ * Requires at least: 5.7
+ * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com
  * License:           GPL v2 or later


### PR DESCRIPTION
### Description of the Change
Bump minimum PHP and WP versions as requested in #74.

Closes #74

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
> Changed - Bump minimum PHP version from 7.0 to 7.4
> Changed - Bump minimum WordPress version from 4.7 to 5.7


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @vikrampm1, @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
