### PR TITLE
Fix issues with how assets are enqueued on the new SVG block

### DIFF
--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -17,7 +17,6 @@ function setup() {
 		return __NAMESPACE__ . "\\$function";
 	};
 
-	add_action( 'enqueue_block_assets', $n( 'blocks_styles' ) );
 	add_filter( 'block_categories_all', $n( 'blocks_categories' ), 10, 2 );
 
 	register_blocks();
@@ -34,32 +33,6 @@ function register_blocks() {
 
 	// Call register function for each block.
 	SafeSvgBlock\register();
-}
-
-/**
- * Enqueue JavaScript/CSS for blocks.
- *
- * @return void
- */
-function blocks_styles() {
-	$fe_file_name          = 'safe-svg-block-frontend';
-	$frontend_dependencies = ( include SAFE_SVG_PLUGIN_DIR . "/dist/$fe_file_name.asset.php" );
-	wp_enqueue_script(
-		'safe-svg-block-script',
-		SAFE_SVG_PLUGIN_URL . 'dist/safe-svg-block-frontend.js',
-		$frontend_dependencies['dependencies'],
-		$frontend_dependencies['version'],
-		true
-	);
-
-	wp_localize_script(
-		'safe-svg-block-script',
-		'safe_svg_personalizer_params',
-		array(
-			'ajax_url'   => esc_url( admin_url( 'admin-ajax.php' ) ),
-			'ajax_nonce' => wp_create_nonce( 'safe-svg-block' ),
-		)
-	);
 }
 
 /**

--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -42,13 +42,6 @@ function register_blocks() {
  * @return void
  */
 function blocks_styles() {
-	wp_enqueue_style(
-		'safe-svg-block-frontend',
-		SAFE_SVG_PLUGIN_URL . '/dist/safe-svg-block-frontend.css',
-		[],
-		SAFE_SVG_VERSION
-	);
-
 	$fe_file_name          = 'safe-svg-block-frontend';
 	$frontend_dependencies = ( include SAFE_SVG_PLUGIN_DIR . "/dist/$fe_file_name.asset.php" );
 	wp_enqueue_script(

--- a/includes/blocks/safe-svg/block.json
+++ b/includes/blocks/safe-svg/block.json
@@ -42,5 +42,5 @@
     "html": false
   },
   "editorScript": "file:../../../dist/safe-svg-block.js",
-  "style": "safe-svg-block-frontend"
+  "style": "file:../../../dist/safe-svg-block-frontend.css"
 }

--- a/safe-svg.php
+++ b/safe-svg.php
@@ -78,7 +78,7 @@ if ( ! class_exists( 'safe_svg' ) ) {
 			$this->sanitizer = new \enshrined\svgSanitize\Sanitizer();
 			$this->sanitizer->minify( true );
 
-			add_filter( 'init', array( $this, 'setup_blocks' ) );
+			add_action( 'init', array( $this, 'setup_blocks' ) );
 			add_filter( 'upload_mimes', array( $this, 'allow_svg' ) );
 			add_filter( 'wp_handle_upload_prefilter', array( $this, 'check_for_svg' ) );
 			add_filter( 'wp_check_filetype_and_ext', array( $this, 'fix_mime_type_svg' ), 75, 4 );


### PR DESCRIPTION
### Description of the Change

A new SVG block was added in PR #80, which went out in the 2.1.0 release. We've gotten a handful of reports around how assets are being loaded for this block, most notably:

- a CSS and JS file are loaded on all FE pages, even those without the block
- the JS file is empty
- an extra slash is in the CSS file URL

This PR fixes all of those issues by removing the JS file from being loaded at all and moving the CSS file from a typical enqueue to being loaded as part of the `block.json`. This ensures the CSS is only loaded on pages that are using the block and it loads the CSS inline instead of loading an extra stylesheet.

Also fix an incorrect use of `add_filter` to be `add_action`

Closes #109 

### How to test the Change

On the current released version (2.1.0) view any page on your site and note that two block related files (a CSS and JS file) are being loaded.

Checkout this branch and note those files are no longer loaded at all, even if a page has an SVG block. Verify the block itself still works and renders as expected.

### Changelog Entry

> Fixed - Only load our block CSS if a page has the SVG block in it and remove an extra slash in the CSS file path.. Remove an unneeded JS block file.

### Credits

Props @dkotter, @freinbichler, @IanDelMar, @ocean90


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
