### PR TITLE
Use absolute path in require

### DIFF
--- a/safe-svg.php
+++ b/safe-svg.php
@@ -97,9 +97,9 @@ if ( ! site_meets_php_requirements() ) {
 	return;
 }
 
-require 'includes/safe-svg-tags.php';
-require 'includes/safe-svg-attributes.php';
-require 'includes/blocks.php';
+require __DIR__ . 'includes/safe-svg-tags.php';
+require __DIR__ . 'includes/safe-svg-attributes.php';
+require __DIR__ . 'includes/blocks.php';
 
 if ( ! class_exists( 'safe_svg' ) ) {
 

--- a/safe-svg.php
+++ b/safe-svg.php
@@ -97,9 +97,9 @@ if ( ! site_meets_php_requirements() ) {
 	return;
 }
 
-require __DIR__ . 'includes/safe-svg-tags.php';
-require __DIR__ . 'includes/safe-svg-attributes.php';
-require __DIR__ . 'includes/blocks.php';
+require __DIR__ . '/includes/safe-svg-tags.php';
+require __DIR__ . '/includes/safe-svg-attributes.php';
+require __DIR__ . '/includes/blocks.php';
 
 if ( ! class_exists( 'safe_svg' ) ) {
 


### PR DESCRIPTION
### Description of the Change

Use absolute path in `require` as in the line above

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
