### PR TITLE
Fix for missing custom classname on the frontend

### DIFF
--- a/includes/blocks/safe-svg/register.php
+++ b/includes/blocks/safe-svg/register.php
@@ -70,11 +70,11 @@ function render_block_callback( $attributes ) {
 			'<div class="safe-svg-cover" style="text-align:%s">
 				<div class="safe-svg-inside %s%s" style="width: %spx; height: %spx;">%s</div>
 			</div>',
-			$attributes['alignment'] ?? 'left',
-			$class_name,
+			isset( $attributes['alignment'] ) ? esc_attr( $attributes['alignment'] ) : 'left',
+			esc_attr( $class_name ),
 			isset( $attributes['className'] ) ? ' ' . esc_attr( $attributes['className'] ) : '',
-			$attributes['dimensionWidth'],
-			$attributes['dimensionHeight'],
+			isset( $attributes['dimensionWidth'] ) ? esc_attr( $attributes['dimensionWidth'] ) : '',
+			isset( $attributes['dimensionHeight'] ) ? esc_attr( $attributes['dimensionHeight'] ) : '',
 			$contents
 		),
 		$contents,

--- a/includes/blocks/safe-svg/register.php
+++ b/includes/blocks/safe-svg/register.php
@@ -72,7 +72,7 @@ function render_block_callback( $attributes ) {
 			</div>',
 			$attributes['alignment'] ?? 'left',
 			$class_name,
-			isset( $attributes['className'] ) ? ' ' . $attributes['className'] : '',
+			isset( $attributes['className'] ) ? ' ' . esc_attr( $attributes['className'] ) : '',
 			$attributes['dimensionWidth'],
 			$attributes['dimensionHeight'],
 			$contents

--- a/includes/blocks/safe-svg/register.php
+++ b/includes/blocks/safe-svg/register.php
@@ -68,10 +68,11 @@ function render_block_callback( $attributes ) {
 		'safe_svg_inline_markup',
 		sprintf(
 			'<div class="safe-svg-cover" style="text-align:%s">
-				<div class="safe-svg-inside %s" style="width: %spx; height: %spx;">%s</div>
+				<div class="safe-svg-inside %s%s" style="width: %spx; height: %spx;">%s</div>
 			</div>',
 			$attributes['alignment'] ?? 'left',
 			$class_name,
+			isset( $attributes['className'] ) ? ' ' . $attributes['className'] : '',
 			$attributes['dimensionWidth'],
 			$attributes['dimensionHeight'],
 			$contents


### PR DESCRIPTION
### Description of the Change

Fixes the missing custom classname on the frontend. It was being applied in the editor, but not when rendering on the front.

Closes #126 

### How to test the Change

1. Insert Safe SVG Icon block
2. Apply a custom class to block
3. Save page / post
4. View source in the frontend to verify the class has been applied

### Changelog Entry

> Fixed - Fix for missing custom classname on the frontend

### Credits

Props @bmarshall511 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
