### PR TITLE
Added a helper function for wp_kses to sanitize a SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ add_filter( 'svg_allowed_tags', function ( $tags ) {
 } );
 ```
 
+### Can `wp_kses` be used with a helper to sanitize an SVG?
+
+Indeed, you can accomplish this with `\SafeSvg\SafeSvgTags\safe_svg_tags::kses_allowed_html()`:
+
+```php
+echo wp_kses('<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 25"><path fill="currentcolor" d="M17.525 9.302H14v-2c0-1.032.084-1.682 1.563-1.682h1.868V2.44a26.065 26.065 0 0 0-2.738-.138C11.98 2.302 10 3.959 10 7v2.3H7v4h3v9h4V13.3l3.066-.001.459-3.996Z"/></svg>', \SafeSvg\SafeSvgTags\safe_svg_tags::kses_allowed_html())
+```
+
 ## Support Level
 
 **Stable:** 10up is not planning to develop any new features for this, but will still respond to bug reports and security concerns. We welcome PRs, but any that include new features should be small and easy to integrate and should not include breaking changes. We otherwise intend to keep this tested up to the most recent version of WordPress.

--- a/includes/safe-svg-tags.php
+++ b/includes/safe-svg-tags.php
@@ -24,4 +24,98 @@ class safe_svg_tags extends \enshrined\svgSanitize\data\AllowedTags {
 		 */
 		return apply_filters( 'svg_allowed_tags', parent::getTags() );
 	}
+
+	/**
+	 * Standard SVG settings for escaping through `wp_kses()` function.
+	 *
+	 * @return array Array of allowed HTML tags and their allowed attributes.
+	 */
+	public function kses_allowed_html() {
+		return array(
+			'svg'            => array(
+				'version'           => true,
+				'class'             => true,
+				'fill'              => true,
+				'height'            => true,
+				'xml:space'         => true,
+				'xmlns'             => true,
+				'xmlns:xlink'       => true,
+				'viewbox'           => true,
+				'enable-background' => true,
+				'width'             => true,
+				'x'                 => true,
+				'y'                 => true,
+			),
+			'path'           => array(
+				'clip-rule'    => true,
+				'd'            => true,
+				'fill'         => true,
+				'fill-rule'    => true,
+				'stroke'       => true,
+				'stroke-width' => true,
+			),
+			'g'              => array(
+				'class'        => true,
+				'clip-rule'    => true,
+				'd'            => true,
+				'transform'    => true,
+				'fill'         => true,
+				'fill-rule'    => true,
+				'stroke'       => true,
+				'stroke-width' => true,
+			),
+			'rect'           => array(
+				'clip-rule'    => true,
+				'd'            => true,
+				'transform'    => true,
+				'fill'         => true,
+				'fill-rule'    => true,
+				'stroke'       => true,
+				'stroke-width' => true,
+				'width'        => true,
+				'height'       => true,
+			),
+			'polygon'        => array(
+				'clip-rule'    => true,
+				'd'            => true,
+				'fill'         => true,
+				'fill-rule'    => true,
+				'stroke'       => true,
+				'stroke-width' => true,
+				'points'       => true,
+			),
+			'circle'         => array(
+				'clip-rule'    => true,
+				'd'            => true,
+				'fill'         => true,
+				'fill-rule'    => true,
+				'stroke'       => true,
+				'stroke-width' => true,
+				'cx'           => true,
+				'cy'           => true,
+				'r'            => true,
+			),
+			'lineargradient' => array(
+				'id'                => true,
+				'gradientunits'     => true,
+				'x'                 => true,
+				'y'                 => true,
+				'x2'                => true,
+				'y2'                => true,
+				'gradienttransform' => true,
+			),
+			'stop'           => array(
+				'offset' => true,
+				'style'  => true,
+			),
+			'image'          => array(
+				'height'     => true,
+				'width'      => true,
+				'xlink:href' => true,
+			),
+			'defs'           => array(
+				'clipPath' => true,
+			),
+		);
+	}
 }

--- a/includes/safe-svg-tags.php
+++ b/includes/safe-svg-tags.php
@@ -30,7 +30,7 @@ class safe_svg_tags extends \enshrined\svgSanitize\data\AllowedTags {
 	 *
 	 * @return array Array of allowed HTML tags and their allowed attributes.
 	 */
-	public function kses_allowed_html() {
+	public static function kses_allowed_html() {
 		return array(
 			'svg'            => array(
 				'version'           => true,

--- a/tests/unit/test-safe-svg-tags.php
+++ b/tests/unit/test-safe-svg-tags.php
@@ -47,4 +47,14 @@ class SafeSvgTagsTest extends TestCase {
 		$this->assertContains( 'customTag', $svg_tags );
 		$this->assertSame( $svg_tags, $filtered_svg_tags );
 	}
+
+	/**
+	 * Test the kses_allowed_html function.
+	 *
+	 * @throws PHPUnit\Framework\AssertionFailedError If the function does not return an array.
+	 */
+	public function test_kses_allowed_html() {
+		$allowed_html = SafeSvg\SafeSvgTags\safe_svg_tags::kses_allowed_html();
+		$this->assertIsArray( $allowed_html );
+	}
 }


### PR DESCRIPTION
### Description of the Change

Added a helper function used for `wp_kses()` to return an array of allowed HTML tags & attributes.

Closes #115

### How to test the Change

Example usage:

```php
echo wp_kses('<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 25"><path fill="currentcolor" d="M17.525 9.302H14v-2c0-1.032.084-1.682 1.563-1.682h1.868V2.44a26.065 26.065 0 0 0-2.738-.138C11.98 2.302 10 3.959 10 7v2.3H7v4h3v9h4V13.3l3.066-.001.459-3.996Z"/></svg>', \SafeSvg\SafeSvgTags\safe_svg_tags::kses_allowed_html())
```

### Changelog Entry

> Added - Added the `kses_allowed_html` helper function for `wp_kses` to sanitize SVG images


### Credits

Props @bmarshall511 


### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
