### PR TITLE
Bump WP tested version to 6.3

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      10up, enshrined, jeffpaul
 Tags:              svg, sanitize, upload, sanitise, security, svg upload, image, vector, file, graphic, media, mime
 Requires at least: 5.7
-Tested up to:      6.2
+Tested up to:      6.3
 Stable tag:        2.1.1
 Requires PHP:      7.4
 License:           GPLv2 or later


### PR DESCRIPTION
### Description of the Change

I've tested this plugin on WordPress 6.3 and have not encountered any issues. This PR bumps the "tested up to" version to 6.3.

Closes #142

### Changelog Entry

> Changed - Bump WordPress "tested up to" version 6.3

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
