### PR TITLE
Disable SVG optimization by default

### DIFF
--- a/includes/optimizer.php
+++ b/includes/optimizer.php
@@ -10,22 +10,26 @@ namespace SafeSVG;
 use enshrined\svgSanitize\Sanitizer;
 
 if ( ! class_exists( '\SafeSVG\Optimizer' ) ) {
+
 	/**
 	 * Class \SafeSVG\Optimizer
 	 */
 	class Optimizer {
+
 		/**
 		 * The name of the nonce to send with the AJAX call.
 		 *
 		 * @var string
 		 */
 		private $nonce_name = 'safe-svg-optimizer';
+
 		/**
 		 * The class constructor.
 		 */
 		public function __construct() {
 			add_action( 'init', [ $this, 'init' ] );
 		}
+
 		/**
 		 * Initialize actions.
 		 *
@@ -35,9 +39,11 @@ if ( ! class_exists( '\SafeSVG\Optimizer' ) ) {
 			if ( true !== $this->is_enabled() ) {
 				return;
 			}
+
 			add_action( 'admin_enqueue_scripts', [ $this, 'enqueues' ] );
 			add_action( 'wp_ajax_safe_svg_optimize', [ $this, 'optimize' ] );
 		}
+
 		/**
 		 * Checks if the Optimizer is enabled.
 		 *
@@ -46,22 +52,34 @@ if ( ! class_exists( '\SafeSVG\Optimizer' ) ) {
 		public function is_enabled(): bool {
 			$has_svg_allowed_tags       = has_filter( 'svg_allowed_tags' );
 			$has_svg_allowed_attributes = has_filter( 'svg_allowed_attributes' );
+
 			/**
-			 * If a dev has added allowed tags or attributes, we should not optimize the SVGs, because the optimizer will not respect their exclusions.
+			 * If a dev has added allowed tags or attributes, we should not
+			 * optimize the SVGs, because the optimizer will not respect their exclusions.
 			 */
 			if ( $has_svg_allowed_tags || $has_svg_allowed_attributes ) {
 				return false;
 			}
+
 			$params = $this->svgo_params();
 			return ( ! empty( $params ) && is_array( $params ) );
 		}
+
 		/**
-		 * The SVGO parameters. Developers can use this filter to pass additional parameters or completely disable the optimizer by passing:
-		 * add_filter( 'safe_svg_svgo_params', '__return_false' );
+		 * The SVGO parameters.
 		 *
 		 * @return mixed|null
 		 */
 		public function svgo_params() {
+			/**
+			 * Filter the params we pass to SVGO.
+			 *
+			 * @since 2.2.0
+			 * @hook safe_svg_svgo_params
+			 *
+			 * @param array $params The params we pass to SVGO.
+			 * @return array
+			 */
 			return apply_filters(
 				'safe_svg_svgo_params',
 				[
@@ -69,6 +87,7 @@ if ( ! class_exists( '\SafeSVG\Optimizer' ) ) {
 				]
 			);
 		}
+
 		/**
 		 * Enqueue the necessary scripts.
 		 *
@@ -84,9 +103,11 @@ if ( ! class_exists( '\SafeSVG\Optimizer' ) ) {
 				'upload.php',
 				'media-new.php',
 			];
+
 			if ( ! in_array( $hook, $allowed_hooks, true ) ) {
 				return;
 			}
+
 			wp_enqueue_script(
 				'safe-svg-admin-scripts',
 				SAFE_SVG_PLUGIN_URL . '/dist/safe-svg-admin.js',
@@ -94,6 +115,7 @@ if ( ! class_exists( '\SafeSVG\Optimizer' ) ) {
 				SAFE_SVG_VERSION,
 				true
 			);
+
 			$params = wp_json_encode(
 				[
 					'ajaxUrl'    => esc_url_raw( admin_url( 'admin-ajax.php' ) ),
@@ -112,6 +134,7 @@ if ( ! class_exists( '\SafeSVG\Optimizer' ) ) {
 				'before'
 			);
 		}
+
 		/**
 		 * Optimize the SVG file.
 		 *
@@ -121,23 +144,32 @@ if ( ! class_exists( '\SafeSVG\Optimizer' ) ) {
 			$svg_url       = filter_input( INPUT_GET, 'svg_url', FILTER_SANITIZE_URL );
 			$svg_id        = filter_input( INPUT_GET, 'svg_id', FILTER_SANITIZE_NUMBER_INT );
 			$attachment_id = ! empty( $svg_id ) ? $svg_id : attachment_url_to_postid( $svg_url );
+
 			if ( empty( $attachment_id ) || ! current_user_can( 'edit_post', $attachment_id ) ) {
 				return;
 			}
+
 			check_ajax_referer( $this->nonce_name, 'svg_nonce' );
+
 			$svg_path = get_attached_file( $attachment_id );
 			if ( empty( $svg_path ) ) {
 				return;
 			}
+
 			$maybe_dirty = $_GET['optimized_svg'];
 			$sanitizer   = new Sanitizer();
 			$sanitizer->minify( true );
 			$sanitized = $sanitizer->sanitize( stripcslashes( $maybe_dirty ) );
+
 			if ( empty( $sanitized ) ) {
 				return;
 			}
+
 			file_put_contents( $svg_path, $sanitized ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
+
 			wp_die();
 		}
+
 	}
+
 }

--- a/includes/optimizer.php
+++ b/includes/optimizer.php
@@ -61,8 +61,18 @@ if ( ! class_exists( '\SafeSVG\Optimizer' ) ) {
 				return false;
 			}
 
-			$params = $this->svgo_params();
-			return ( ! empty( $params ) && is_array( $params ) );
+			/**
+			 * Filter to enable the optimizer.
+			 *
+			 * Note: this feature is disabled by default.
+			 *
+			 * @since 2.2.0
+			 * @hook safe_svg_optimizer_enabled
+			 *
+			 * @param bool $enabled Whether the optimizer is enabled.
+			 * @return bool
+			 */
+			return apply_filters( 'safe_svg_optimizer_enabled', false );
 		}
 
 		/**

--- a/includes/optimizer.php
+++ b/includes/optimizer.php
@@ -120,7 +120,7 @@ if ( ! class_exists( '\SafeSVG\Optimizer' ) ) {
 
 			wp_enqueue_script(
 				'safe-svg-admin-scripts',
-				SAFE_SVG_PLUGIN_URL . '/dist/safe-svg-admin.js',
+				SAFE_SVG_PLUGIN_URL . 'dist/safe-svg-admin.js',
 				[ 'wp-data', 'utils' ],
 				SAFE_SVG_VERSION,
 				true

--- a/safe-svg.php
+++ b/safe-svg.php
@@ -104,6 +104,7 @@ require __DIR__ . '/includes/safe-svg-attributes.php';
 require __DIR__ . '/includes/safe-svg-settings.php';
 require __DIR__ . '/includes/blocks.php';
 require __DIR__ . '/includes/optimizer.php';
+
 new \SafeSVG\Optimizer();
 
 if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {


### PR DESCRIPTION
### Description of the Change

In #79, we added SVG optimization using the SVGO library. This optimization is enabled by default and the only way to turn it off was through a filter. I had some concerns with this feature (around performance and potential issues with stripping params we may want to keep) and so in order to not delay a 2.2.0 release any longer, talked to @jeffpaul and decided that we would keep this feature in place but we would change this to be disabled by default.

A new filter has been added (`safe_svg_optimizer_enabled`) that returns `false` by default. Users that want to try out this new optimization feature will have to hook into that filter and return `true`:

```php
add_filter( 'safe_svg_optimizer_enabled', '__return_true' );
```

This gives people the opportunity to test this out and decide whether they want this extra optimization or not (and doesn't impact sites that don't care about this). If enough people use and like this feature, in the future we can look to either enable this by default or add an admin setting to turn this on/off.

### How to test the Change

Follow the steps outlined in #79, once you add the line of code above. Without that line in place, ensure optimization doesn't happen and everything works as expected.

### Changelog Entry

> Changed - Don't run SVGO optimization by default and instead make this an opt-in feature.

### Credits

Props @dkotter, @jeffpaul 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
