### PR TITLE
Update classname

### DIFF
--- a/includes/blocks/safe-svg/edit.js
+++ b/includes/blocks/safe-svg/edit.js
@@ -48,7 +48,7 @@ const SafeSvgBlockEdit = ( props ) => {
 	} = attributes;
 	const blockProps = useBlockProps(
 		{
-			className:` wp-block-safe-svg-svg-icon`,
+			className:` wp-block-safe-svg-svg-icon safe-svg-cover`,
 			style: {
 				textAlign: alignment,
 			}

--- a/includes/blocks/safe-svg/edit.js
+++ b/includes/blocks/safe-svg/edit.js
@@ -48,7 +48,7 @@ const SafeSvgBlockEdit = ( props ) => {
 	} = attributes;
 	const blockProps = useBlockProps(
 		{
-			className:` safe-svg-cover`,
+			className:` wp-block-safe-svg-svg-icon`,
 			style: {
 				textAlign: alignment,
 			}

--- a/includes/blocks/safe-svg/frontend.scss
+++ b/includes/blocks/safe-svg/frontend.scss
@@ -1,4 +1,4 @@
-.safe-svg-cover {
+.wp-block-safe-svg-svg-icon {
     text-align: center;
 
     .safe-svg-inside {

--- a/includes/blocks/safe-svg/frontend.scss
+++ b/includes/blocks/safe-svg/frontend.scss
@@ -1,4 +1,4 @@
-.wp-block-safe-svg-svg-icon {
+.safe-svg-cover {
     text-align: center;
 
     .safe-svg-inside {

--- a/includes/blocks/safe-svg/register.php
+++ b/includes/blocks/safe-svg/register.php
@@ -67,7 +67,7 @@ function render_block_callback( $attributes ) {
 	return apply_filters(
 		'safe_svg_inline_markup',
 		sprintf(
-			'<div class="safe-svg-cover" style="text-align: %s;">
+			'<div class="wp-block-safe-svg-svg-icon" style="text-align: %s;">
 				<div class="safe-svg-inside %s%s" style="width: %spx; height: %spx; background-color: var(--wp--preset--color--%s); color: var(--wp--preset--color--%s); padding-top: %s; padding-right: %s; padding-bottom: %s; padding-left: %s; margin-top: %s; margin-right: %s; margin-bottom: %s; margin-left: %s;">%s</div>
 			</div>',
 			isset( $attributes['alignment'] ) ? esc_attr( $attributes['alignment'] ) : 'left',

--- a/includes/blocks/safe-svg/register.php
+++ b/includes/blocks/safe-svg/register.php
@@ -67,7 +67,7 @@ function render_block_callback( $attributes ) {
 	return apply_filters(
 		'safe_svg_inline_markup',
 		sprintf(
-			'<div class="wp-block-safe-svg-svg-icon" style="text-align: %s;">
+			'<div class="wp-block-safe-svg-svg-icon safe-svg-cover" style="text-align: %s;">
 				<div class="safe-svg-inside %s%s" style="width: %spx; height: %spx; background-color: var(--wp--preset--color--%s); color: var(--wp--preset--color--%s); padding-top: %s; padding-right: %s; padding-bottom: %s; padding-left: %s; margin-top: %s; margin-right: %s; margin-bottom: %s; margin-left: %s;">%s</div>
 			</div>',
 			isset( $attributes['alignment'] ) ? esc_attr( $attributes['alignment'] ) : 'left',


### PR DESCRIPTION
### Description of the Change
Update the root class name to make `theme.json` changes possible. 

If you add this to your theme.json the css is applied to the block classname `wp-block-safe-svg-svg-icon` so this does not get applied to the block.

```
      "safe-svg/svg-icon": {
        "border": {
          "color": "var(--wp--preset--color--gray-200)",
          "radius": "8px",
          "style": "solid",
          "width": "1px"
        },
      }
```

### How to test the Change
Apply the theme.json change above against develop and this branch to see the difference

### Changelog Entry
> Added support theme.json block changes

### Credits
@tobeycodes 

### Checklist:
- [X] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
