### PR TITLE
Bump WordPress "tested up to" version 6.4 on `trunk`

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      10up, enshrined, jeffpaul
 Tags:              svg, sanitize, upload, sanitise, security, svg upload, image, vector, file, graphic, media, mime
 Requires at least: 5.7
-Tested up to:      6.3
+Tested up to:      6.4
 Stable tag:        2.2.1
 Requires PHP:      7.4
 License:           GPLv2 or later


### PR DESCRIPTION
Ports #162 to `trunk` to hopefully trigger the Readme action and push the update to WP.org.