### PR TITLE
ensure blocks are present before processing

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,9 @@
 {
-  "plugins": [".", "./tests/cypress/test-plugin"],
+  "plugins": [
+    ".",
+    "./tests/cypress/test-plugin/e2e-test-plugin.php",
+    "./tests/cypress/test-plugin/e2e-test-plugin-optimizer.php"
+  ],
   "env": {
     "tests": {
       "mappings": {

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -246,7 +246,7 @@ import {select, subscribe} from '@wordpress/data';
     subscribe(() => {
         if (editorStore.isSavingPost()) {
             const changes = editorStore.getPostEdits();
-            // maske sure we have blocks to process
+            // make sure we have blocks to process
             if (!Array.isArray(changes.blocks) || !changes.blocks.length) {
                 return;
             }

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -246,6 +246,10 @@ import {select, subscribe} from '@wordpress/data';
     subscribe(() => {
         if (editorStore.isSavingPost()) {
             const changes = editorStore.getPostEdits();
+            // maske sure we have blocks to process
+            if (!Array.isArray(changes.blocks) || !changes.blocks.length) {
+                return;
+            }
             for (const changedBlock of changes.blocks) {
                 const blockName = changedBlock?.name ?? '';
                 const innerBlocks = changedBlock?.innerBlocks ?? [];

--- a/tests/cypress/cypress.config.js
+++ b/tests/cypress/cypress.config.js
@@ -1,6 +1,7 @@
 const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
+  chromeWebSecurity: false,
   fixturesFolder: 'tests/cypress/fixtures',
   screenshotsFolder: 'tests/cypress/screenshots',
   videosFolder: 'tests/cypress/videos',

--- a/tests/cypress/e2e/safe-svg.cy.js
+++ b/tests/cypress/e2e/safe-svg.cy.js
@@ -72,4 +72,13 @@ describe('Safe SVG Tests', () => {
 
     cy.get('.media-item .error-div.error').should('exist').contains('has failed to upload');
   });
+
+
+  // Test plugin doesn't break the block editor when no blocks are added
+  it('Plugin should not break the block editor when optimizer enabled', () => {
+    // Activate Test Plugin
+    cy.deactivatePlugin('safe-svg-cypress-test-plugin');
+    cy.activatePlugin('safe-svg-cypress-optimizer-test-plugin');
+    cy.createPost('Hello World');
+  });
 });

--- a/tests/cypress/test-plugin/e2e-test-plugin-optimizer.php
+++ b/tests/cypress/test-plugin/e2e-test-plugin-optimizer.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Plugin name: Safe SVG Cypress Optimizer Test plugin
+ * Description: Test plugin for Safe SVG to test the optimizer.
+ *
+ * @package safe-svg
+ */
+
+/**
+ * Optimizer and allowed attributes can't be mutually enabled, hence the secondary testing plugin.
+ */
+add_filter('safe_svg_optimizer_enabled', '__return_true');


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Set `safe_svg_optimizer_enabled` filter to return true 
`add_filter( 'safe_svg_optimizer_enabled', '__return_true' );`
3. Create a new Page, populate the page title and featured image. Do not populate any blocks.
4. Publish the post.
5. Page should publish without normally without issue.

### Changelog Entry
Fixed fatal JS error when optimization is enabled and page is published without blocks.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @tictag @psorensen


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [ ] All new and existing tests pass.
