### PR TITLE
fix width and height metadata condition on svg_dimensions function

### DIFF
--- a/safe-svg.php
+++ b/safe-svg.php
@@ -591,7 +591,7 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 			$width    = 0;
 			$height   = 0;
 
-			if ( $svg && ! empty( $metadata['width'] ) && empty( $metadata['height'] ) ) {
+			if ( $svg && ! empty( $metadata['width'] ) && ! empty( $metadata['height'] ) ) {
 				$width  = floatval( $metadata['width'] );
 				$height = floatval( $metadata['height'] );
 			} elseif ( $svg ) {

--- a/tests/unit/test-safe-svg.php
+++ b/tests/unit/test-safe-svg.php
@@ -262,6 +262,53 @@ class SafeSvgTest extends TestCase {
 							),
 						),
 					),
+					array(
+						'file' => __DIR__ . '/files/svgNoDimensions.svg',
+						'sizes' => array(
+							'thumbnail' => array(
+								'width' => 150,
+								'height' => 150,
+								'crop' => 1,
+								'file' => 'svgNoDimensions.svg',
+								'mime-type' => 'image/svg+xml',
+							),
+							'medium' => array(
+								'width' => 300,
+								'height' => 300,
+								'crop' => 0, // Set to 0 if you don't want to crop
+								'file' => 'svgNoDimensions.svg',
+								'mime-type' => 'image/svg+xml',
+							),
+							'medium_large' => array(
+								'width' => 768,
+								'height' => 0,
+								'crop' => 0,
+								'file' => 'svgNoDimensions.svg',
+								'mime-type' => 'image/svg+xml',
+							),
+							'large' => array(
+								'width' => 1024,
+								'height' => 1024,
+								'crop' => 0,
+								'file' => 'svgNoDimensions.svg',
+								'mime-type' => 'image/svg+xml',
+							),
+							'1536x1536' => array(
+								'width' => 1536,
+								'height' => 1536,
+								'crop' => 0,
+								'file' => 'svgNoDimensions.svg',
+								'mime-type' => 'image/svg+xml',
+							),
+							'2048x2048' => array(
+								'width' => 2048,
+								'height' => 2048,
+								'crop' => 0,
+								'file' => 'svgNoDimensions.svg',
+								'mime-type' => 'image/svg+xml',
+							),
+						),
+					),
 				),
 			)
 		);

--- a/tests/unit/test-safe-svg.php
+++ b/tests/unit/test-safe-svg.php
@@ -263,51 +263,7 @@ class SafeSvgTest extends TestCase {
 						),
 					),
 					array(
-						'file' => __DIR__ . '/files/svgNoDimensions.svg',
-						'sizes' => array(
-							'thumbnail' => array(
-								'width' => 150,
-								'height' => 150,
-								'crop' => 1,
-								'file' => 'svgNoDimensions.svg',
-								'mime-type' => 'image/svg+xml',
-							),
-							'medium' => array(
-								'width' => 300,
-								'height' => 300,
-								'crop' => 0, // Set to 0 if you don't want to crop
-								'file' => 'svgNoDimensions.svg',
-								'mime-type' => 'image/svg+xml',
-							),
-							'medium_large' => array(
-								'width' => 768,
-								'height' => 0,
-								'crop' => 0,
-								'file' => 'svgNoDimensions.svg',
-								'mime-type' => 'image/svg+xml',
-							),
-							'large' => array(
-								'width' => 1024,
-								'height' => 1024,
-								'crop' => 0,
-								'file' => 'svgNoDimensions.svg',
-								'mime-type' => 'image/svg+xml',
-							),
-							'1536x1536' => array(
-								'width' => 1536,
-								'height' => 1536,
-								'crop' => 0,
-								'file' => 'svgNoDimensions.svg',
-								'mime-type' => 'image/svg+xml',
-							),
-							'2048x2048' => array(
-								'width' => 2048,
-								'height' => 2048,
-								'crop' => 0,
-								'file' => 'svgNoDimensions.svg',
-								'mime-type' => 'image/svg+xml',
-							),
-						),
+						'filesize' => 1001, // wp_get_attachment_metadata response for ./files/svgNoDimensions.svg file doesn't contain dimensions and sizes array.
 					),
 				),
 			)


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Remediation work on the PR https://github.com/10up/safe-svg/pull/154 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
