### PR TITLE
Upgrade the `download-artifact` from v3 to v4

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Download build zip
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ github.event.repository.name }}
         path: ${{ github.event.repository.name }}
@@ -66,7 +66,7 @@ jobs:
           npx mochawesome-report-generator tests/cypress/reports/mochawesome.json -o tests/cypress/reports/
           cat ./tests/cypress/reports/mochawesome.md >> $GITHUB_STEP_SUMMARY
     - name: Make artifacts available
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: cypress-artifact


### PR DESCRIPTION
### Description of the Change
The PR proposes upgrading the `download-artifact` to v4. This upgrade is related to the upgrade of `upload-artifact` to v4 in PR https://github.com/10up/action-wordpress-plugin-build-zip/pull/3. Version 4 contains breaking changes, and this PR ensures that everything keeps working after the build zip action updates the `upload-artifact` to v4.

> [!NOTE]
> Please merge this PR after the action https://github.com/marketplace/actions/wordpress-plugin-build-zip gets released.

### How to test the Change
Please ensure that the E2E test action runs successfully after the release of the action available at https://github.com/marketplace/actions/wordpress-plugin-build-zip.

### Changelog Entry
> Changed - Upgrade the `download-artifact` from v3 to v4

### Credits
Props @iamdharmesh 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
