### PR TITLE
Ensure the svg file loads properly before we access it's properties

### DIFF
--- a/safe-svg.php
+++ b/safe-svg.php
@@ -597,6 +597,11 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 			} elseif ( $svg ) {
 				$svg = @simplexml_load_file( $svg ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 
+				// Ensure the svg could be loaded.
+				if ( ! $svg ) {
+					return false;
+				}
+
 				$attributes = $svg->attributes();
 
 				if ( isset( $attributes->viewBox ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase


### PR DESCRIPTION
### Description of the Change

In #154 some refactoring was done to help with performance of calculating the svg dimensions. But this inadvertently removed some code that was in place to ensure an svg could load properly before trying to access its dimensions.

We have a call to `simplexml_load_file` and then we access the svg attributes from that. But if that function returns `false`, this fails. Previously we had an `if` statement in place to prevent this from being a problem. This PR adds that same thing back but instead of a large nested statement, we return `false` early if the svg can't be loaded.

Closes #184

### How to test the Change

You need to have a valid svg file that you upload and then delete this from your disk (but not from WordPress). In addition, you need to delete the meta for that attachment so we don't have the height and width saved (otherwise these will be returned and the `simplexml_load_file` call will never happen).

Once you ensure both of those are done, you should see a fatal error prior to this PR. With this PR checked out, you shouldn't get a fatal anymore.

### Changelog Entry

> Fixed - Ensure the svg file can be loaded before we try accessing it's attributes.

### Credits

Props @dkotter, @metashield-ie, @ocean90 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
