### PR TITLE
Add another dependency to our optimizer script

### DIFF
--- a/includes/optimizer.php
+++ b/includes/optimizer.php
@@ -121,7 +121,7 @@ if ( ! class_exists( '\SafeSVG\Optimizer' ) ) {
 			wp_enqueue_script(
 				'safe-svg-admin-scripts',
 				SAFE_SVG_PLUGIN_URL . 'dist/safe-svg-admin.js',
-				[ 'wp-data', 'utils' ],
+				[ 'wp-data', 'wp-editor', 'utils' ],
 				SAFE_SVG_VERSION,
 				true
 			);


### PR DESCRIPTION
### Description of the Change

As described in #182, when using the optimizer feature and running in the Classic Editor, there's a chance for JS errors that can cause conflicts with other features (in this case Yoast SEO).

The problem is we call the method `isSavingPost` which doesn't natively exist in the Classic Editor. This PR fixes this by adding `wp-editor` as a dependency to our optimizer script.

Closes #182

### How to test the Change

1. In a clean environment, install the Classic Editor plugin, Yoast SEO and Safe SVG
2. Add the following code to turn on the optimizer feature: `add_filter( 'safe_svg_optimizer_enabled', '__return_true' );`
3. Create a new classic post and you should see a JS error in the console. In addition, the Yoast SEO panel won't load properly
4. Checkout this PR and ensure that error goes away
5. If desired, deactivate the Classic Editor plugin and test that things still work properly in the Block Editor

### Changelog Entry

> Fixed - Ensure we don't throw JS errors in the Classic Editor when the optimizer feature is turned on.

### Credits

Props @dkotter, @turtlepod 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
