### PR TITLE
Add a filter around the return value from our `current_user_can_upload_svg` method

### DIFF
--- a/safe-svg.php
+++ b/safe-svg.php
@@ -153,13 +153,24 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 		 */
 		public function current_user_can_upload_svg() {
 			$upload_roles = get_option( 'safe_svg_upload_roles', [] );
+			$can_upload   = false;
 
-			// Fallback to upload_files check for backwards compatibility.
 			if ( empty( $upload_roles ) ) {
-				return current_user_can( 'upload_files' );
+				// Fallback to upload_files check for backwards compatibility.
+				$can_upload = current_user_can( 'upload_files' );
+			} else {
+				// Use our custom capability if some upload roles are set.
+				$can_upload = current_user_can( 'safe_svg_upload_svg' );
 			}
 
-			return current_user_can( 'safe_svg_upload_svg' );
+			/**
+			 * Determine if the current user can upload an svg.
+			 *
+			 * @param bool $can_upload Can the current user upload an svg?
+			 *
+			 * @return bool
+			 */
+			return (bool) apply_filters( 'safe_svg_current_user_can_upload', $can_upload );
 		}
 
 		/**


### PR DESCRIPTION
### Description of the Change

This PR adds a new filter, `safe_svg_current_user_can_upload`, around the returned value from our `current_user_can_upload_svg` method. This filter allows others to have more fine-tune control on who can or cannot upload svgs. For instance, this would allow you to lock down uploads to specific users, instead of specific roles. Or would allow you to allow non-logged in users the ability to upload svgs.

Closes #192 

### How to test the Change

1. With this PR checked out, go to the Media Settings page and ensure your user account has permissions to upload
2. Test uploading an svg and ensure it works
3. Switch to an account that doesn't have permission to upload
4. Ensure svgs aren't allowed
5. Now use the new `current_user_can_upload_svg` and modify permissions, running through the tests again to ensure things work. As an example, could add `add_filter( 'safe_svg_current_user_can_upload', '__return_false' );` and ensure that no one can upload svgs, or `add_filter( 'safe_svg_current_user_can_upload', '__return_true' );` and ensure everyone can upload svgs.

### Changelog Entry

> Added - New filter, `safe_svg_current_user_can_upload`, allowing more control over who can upload svg files.

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
