### PR TITLE
Fix fatal error when "admin_post_thumbnail_html" filter is applied with null "$thumbnail_id" param

### DIFF
--- a/safe-svg.php
+++ b/safe-svg.php
@@ -401,13 +401,13 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 		/**
 		 * If the featured image is an SVG we wrap it in an SVG class so we can apply our CSS fix.
 		 *
-		 * @param string $content Admin post thumbnail HTML markup.
-		 * @param int    $post_id Post ID.
-		 * @param int    $thumbnail_id Thumbnail ID.
+		 * @param string   $content Admin post thumbnail HTML markup.
+		 * @param int      $post_id Post ID.
+		 * @param int|null $thumbnail_id Thumbnail attachment ID, or null if there isn't one.
 		 *
 		 * @return string
 		 */
-		public function featured_image_fix( $content, $post_id, $thumbnail_id ) {
+		public function featured_image_fix( $content, $post_id, $thumbnail_id = null ) {
 			$mime = get_post_mime_type( $thumbnail_id );
 
 			if ( 'image/svg+xml' === $mime ) {

--- a/tests/unit/test-safe-svg.php
+++ b/tests/unit/test-safe-svg.php
@@ -341,5 +341,16 @@ class SafeSvgTest extends TestCase {
 
 		$response = $this->instance->featured_image_fix( 'test', 1, 1 );
 		$this->assertSame( '<span class="svg">test</span>', $response );
+
+		\WP_Mock::userFunction(
+			'get_post_mime_type',
+			array(
+				'args'   => null,
+				'return' => false,
+			)
+		);
+
+		$response = $this->instance->featured_image_fix( 'test', 1 );
+		$this->assertSame( 'test', $response );
 	}
 }


### PR DESCRIPTION
### Description of the Change
The `admin_post_thumbnail_html` filter is allowing the `$thumbnail_id` parameter to be null or undefined but the when a callback for that hook is registered in the plugin, the `$thumbnail_id` parameter is set to always be defined, thus filter application with just two arguments are throwing fatal errors when the plugin is activated.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #195

### How to test the Change
* In the theme's `functions.php` file add the following command 
```
add_action( 'init', 'testing_safe_svg' );
function testing_safe_svg() {
	$content = apply_filters( 'admin_post_thumbnail_html', '', 1 );
}
```

### Changelog Entry
> Fixed - Fatal error when applying the "admin_post_thumbnail_html" with just two arguments.



### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @kmgalanakis 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
