### PR TITLE
Prevent fatal error when filtered block categories array is null.

### DIFF
--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -43,6 +43,10 @@ function register_blocks() {
  * @return array Filtered categories.
  */
 function blocks_categories( $categories ) {
+	if ( ! is_array( $categories ) ) {
+		$categories = [];
+	}
+
 	return array_merge(
 		$categories,
 		array(


### PR DESCRIPTION
### Description of the Change
This PR adds a fix to prevent a PHP fatal error when the value of the filtered block categories is not an array. This could happen when a third-party plugin or them is modifying the value of the filtered block categories with a non-appropriate value.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #199

### How to test the Change
Add the following to your theme's function.php file

```
add_action( 'block_categories_all', 'nullify_block_categories' );
function nullify_block_categories() {
	return null;
}
```

### Changelog Entry
> Fixed - Prevent PHP fatal error when the value of the filtered block categories is not an array.


### Credits
Props @kmgalanakis


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
