### PR TITLE
Fix/194 PHP Deprecated Warning

### DIFF
--- a/safe-svg.php
+++ b/safe-svg.php
@@ -699,6 +699,10 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 		 */
 		public function disable_srcset( $image_meta, $size_array, $image_src, $attachment_id ) {
 			if ( $attachment_id && 'image/svg+xml' === get_post_mime_type( $attachment_id ) ) {
+				// Convert to array if not already to avoid PHP warnings.
+				if ( ! is_array( $image_meta ) ) {
+					$image_meta = array();
+				}
 				$image_meta['sizes'] = array();
 			}
 

--- a/safe-svg.php
+++ b/safe-svg.php
@@ -698,11 +698,7 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 		 * @param int    $attachment_id The image attachment ID.
 		 */
 		public function disable_srcset( $image_meta, $size_array, $image_src, $attachment_id ) {
-			if ( $attachment_id && 'image/svg+xml' === get_post_mime_type( $attachment_id ) ) {
-				// Convert to array if not already to avoid PHP warnings.
-				if ( ! is_array( $image_meta ) ) {
-					$image_meta = array();
-				}
+			if ( $attachment_id && 'image/svg+xml' === get_post_mime_type( $attachment_id ) && is_array( $image_meta ) ) {
 				$image_meta['sizes'] = array();
 			}
 


### PR DESCRIPTION
### Description of the Change

This PR handles the case where the image_meta is not an array and sets it to an empty array to avoid PHP warnings.

Closes #194

### How to test the Change

As this is not a straightforward issue so it is difficult to write steps to regenerate the issue.

### Changelog Entry

> Fixed - Fixed - Handled PHP warning when the `$image_meta` is not an array.

### Credits
Props @drazenbebic, @kirtangajjar, @faisal-alvi , @dkotter 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
