### PR TITLE
Fix/only allow svg when uploading

### DIFF
--- a/safe-svg.php
+++ b/safe-svg.php
@@ -129,6 +129,7 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 			$this->sanitizer->minify( true );
 
 			add_action( 'init', array( $this, 'setup_blocks' ) );
+			add_action( 'load-upload.php', array( $this, 'allow_svg_from_upload' ) );
 			add_filter( 'wp_handle_sideload_prefilter', array( $this, 'check_for_svg' ) );
 			add_filter( 'wp_handle_upload_prefilter', array( $this, 'check_for_svg' ) );
 			add_filter( 'wp_prepare_attachment_for_js', array( $this, 'fix_admin_preview' ), 10, 3 );
@@ -141,6 +142,16 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 			add_filter( 'wp_calculate_image_srcset_meta', array( $this, 'disable_srcset' ), 10, 4 );
 
 			new safe_svg_settings();
+		}
+
+		/**
+		 * Allow SVG uploads from the wp-admin/upload.php screen. Without this, you cannot upload SVGs from the media grid view.
+		 *
+		 * @return void
+		 */
+		public function allow_svg_from_upload() {
+			add_filter( 'upload_mimes', array( $this, 'allow_svg' ) );
+			add_filter( 'wp_check_filetype_and_ext', array( $this, 'fix_mime_type_svg' ), 75, 4 );
 		}
 
 		/**

--- a/safe-svg.php
+++ b/safe-svg.php
@@ -129,10 +129,8 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 			$this->sanitizer->minify( true );
 
 			add_action( 'init', array( $this, 'setup_blocks' ) );
-			add_filter( 'upload_mimes', array( $this, 'allow_svg' ) );
 			add_filter( 'wp_handle_sideload_prefilter', array( $this, 'check_for_svg' ) );
 			add_filter( 'wp_handle_upload_prefilter', array( $this, 'check_for_svg' ) );
-			add_filter( 'wp_check_filetype_and_ext', array( $this, 'fix_mime_type_svg' ), 75, 4 );
 			add_filter( 'wp_prepare_attachment_for_js', array( $this, 'fix_admin_preview' ), 10, 3 );
 			add_filter( 'wp_get_attachment_image_src', array( $this, 'one_pixel_fix' ), 10, 4 );
 			add_filter( 'admin_post_thumbnail_html', array( $this, 'featured_image_fix' ), 10, 3 );
@@ -242,7 +240,18 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 			}
 
 			$file_name   = isset( $file['name'] ) ? $file['name'] : '';
+
+			// Allow SVGs to be uploaded when this function runs.
+			add_filter( 'upload_mimes', array( $this, 'allow_svg' ) );
+			add_filter( 'wp_check_filetype_and_ext', array( $this, 'fix_mime_type_svg' ), 75, 4 );
+
 			$wp_filetype = wp_check_filetype_and_ext( $file['tmp_name'], $file_name );
+
+			// Remove the SVG mime type after we've sanitized the file.
+			// We need to utilize the pre_move_uploaded_file filter to ensure we can remove the filters after the file has been full-processed.
+			// This is because wp_check_filetype_and_ext() is called multiple times during the upload process.
+			add_filter( 'pre_move_uploaded_file', array( $this, 'pre_move_uploaded_file' ) );
+
 			$type        = ! empty( $wp_filetype['type'] ) ? $wp_filetype['type'] : '';
 
 			if ( 'image/svg+xml' === $type ) {
@@ -264,6 +273,23 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 			}
 
 			return $file;
+		}
+
+		/**
+		 * Remove the filters after the file has been processed.
+		 *
+		 * We need to utilize the pre_move_uploaded_file filter to ensure we can remove the filters after the file has been full-processed.
+		 * This is because wp_check_filetype_and_ext() is called multiple times during the upload process.
+		 *
+		 * @param string $move_new_file The new file path. We don't touch this, just return it.
+		 *
+		 * @return string
+		 */
+		public function pre_move_uploaded_file( $move_new_file ) {
+			remove_filter( 'wp_check_filetype_and_ext', array( $this, 'fix_mime_type_svg' ), 75 );
+			remove_filter( 'upload_mimes', array( $this, 'allow_svg' ) );
+
+			return $move_new_file;
 		}
 
 		/**

--- a/safe-svg.php
+++ b/safe-svg.php
@@ -128,8 +128,14 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 			$this->sanitizer = new Sanitizer();
 			$this->sanitizer->minify( true );
 
-			add_action( 'init', array( $this, 'setup_blocks' ) );
+			// Allow SVG uploads from specific contexts.
 			add_action( 'load-upload.php', array( $this, 'allow_svg_from_upload' ) );
+			add_action( 'load-post-new.php', array( $this, 'allow_svg_from_upload' ) );
+			add_action( 'load-post.php', array( $this, 'allow_svg_from_upload' ) );
+			add_action( 'load-site-editor.php', array( $this, 'allow_svg_from_upload' ) );
+
+			// Init all the things.
+			add_action( 'init', array( $this, 'setup_blocks' ) );
 			add_filter( 'wp_handle_sideload_prefilter', array( $this, 'check_for_svg' ) );
 			add_filter( 'wp_handle_upload_prefilter', array( $this, 'check_for_svg' ) );
 			add_filter( 'wp_prepare_attachment_for_js', array( $this, 'fix_admin_preview' ), 10, 3 );

--- a/tests/cypress/e2e/safe-svg.cy.js
+++ b/tests/cypress/e2e/safe-svg.cy.js
@@ -3,10 +3,16 @@ describe('Safe SVG Tests', () => {
     cy.login();
   });
 
-  it('Admin can upload SVG image', () => {
+  it('Admin can upload SVG image via add new media file', () => {
     cy.uploadMedia('.wordpress-org/icon.svg');
     cy.get('.media-item .media-list-title, .media-item .title').should('exist').contains('icon');
     cy.get('.media-item a.edit-attachment').should('exist').contains('Edit');
+  });
+
+  it('Admin can upload SVG image via the media grid', () => {
+    cy.uploadMediaThroughGrid('.wordpress-org/icon.svg').then((attachmentId) => {
+      cy.get(`.attachments .attachment[data-id="${attachmentId}"]`).should('exist');
+    });
   });
 
   /**

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -15,5 +15,6 @@ require_once TEST_PLUGIN_DIR . '/vendor/autoload.php';
 WP_Mock::bootstrap();
 
 \WP_Mock::userFunction( 'plugin_dir_url' );
+\WP_Mock::userFunction( 'remove_filter' );
 
 require TEST_PLUGIN_DIR . '/safe-svg.php';

--- a/tests/unit/test-safe-svg.php
+++ b/tests/unit/test-safe-svg.php
@@ -41,9 +41,8 @@ class SafeSvgTest extends TestCase {
 	 * Test constructor.
 	 */
 	public function test_constructor() {
-		\WP_Mock::expectFilterAdded( 'upload_mimes', array( $this->instance, 'allow_svg' ) );
 		\WP_Mock::expectFilterAdded( 'wp_handle_upload_prefilter', array( $this->instance, 'check_for_svg' ) );
-		\WP_Mock::expectFilterAdded( 'wp_check_filetype_and_ext', array( $this->instance, 'fix_mime_type_svg' ), 75, 4 );
+		\WP_Mock::expectFilterAdded( 'wp_handle_sideload_prefilter', array( $this->instance, 'check_for_svg' ) );
 		\WP_Mock::expectFilterAdded( 'wp_prepare_attachment_for_js', array( $this->instance, 'fix_admin_preview' ), 10, 3 );
 		\WP_Mock::expectFilterAdded( 'wp_get_attachment_image_src', array( $this->instance, 'one_pixel_fix' ), 10, 4 );
 		\WP_Mock::expectFilterAdded( 'admin_post_thumbnail_html', array( $this->instance, 'featured_image_fix' ), 10, 3 );
@@ -158,6 +157,10 @@ class SafeSvgTest extends TestCase {
 			'tmp_name' => $temp,
 			'name'     => 'svgTestOne.svg',
 		);
+
+		\WP_Mock::expectFilterAdded( 'upload_mimes', array( $this->instance, 'allow_svg' ) );
+		\WP_Mock::expectFilterAdded( 'wp_check_filetype_and_ext', array( $this->instance, 'fix_mime_type_svg' ), 75, 4 );
+		\WP_Mock::expectFilterAdded( 'pre_move_uploaded_file', array( $this->instance, 'pre_move_uploaded_file' ) );
 
 		$this->instance->check_for_svg( $file );
 

--- a/tests/unit/test-safe-svg.php
+++ b/tests/unit/test-safe-svg.php
@@ -41,6 +41,7 @@ class SafeSvgTest extends TestCase {
 	 * Test constructor.
 	 */
 	public function test_constructor() {
+		\WP_Mock::expectActionAdded( 'load-upload.php', array( $this->instance, 'allow_svg_from_upload' ) );
 		\WP_Mock::expectFilterAdded( 'wp_handle_upload_prefilter', array( $this->instance, 'check_for_svg' ) );
 		\WP_Mock::expectFilterAdded( 'wp_handle_sideload_prefilter', array( $this->instance, 'check_for_svg' ) );
 		\WP_Mock::expectFilterAdded( 'wp_prepare_attachment_for_js', array( $this->instance, 'fix_admin_preview' ), 10, 3 );


### PR DESCRIPTION
### Description of the Change
Updates the plugin to only add SVGs as an allowed type, when the sanitiser will be able to run on those files.


### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
> Developer - Non-functional update

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
