### PR TITLE
Bump: "Tested up to" WP 6.7

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#6.4'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#6.5'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ SVG Optimization is done through the following library: [https://github.com/svg/
 ## Requirements
 
 * PHP 7.4+
-* [WordPress](http://wordpress.org/) 6.4+
+* [WordPress](http://wordpress.org/) 6.5+
 
 ## Installation
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Safe SVG ===
 Contributors:      10up, enshrined, jeffpaul
 Tags:              svg, security, media, vector, mime
-Tested up to:      6.6
+Tested up to:      6.7
 Stable tag:        2.2.6
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html

--- a/safe-svg.php
+++ b/safe-svg.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://wordpress.org/plugins/safe-svg/
  * Description:       Enable SVG uploads and sanitize them to stop XML/SVG vulnerabilities in your WordPress website
  * Version:           2.2.6
- * Requires at least: 6.4
+ * Requires at least: 6.5
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com


### PR DESCRIPTION
### Description of the Change
Updates WordPress "Tested Up To" version to 6.7.

Closes https://github.com/10up/safe-svg/issues/231

### How to test the Change

### Changelog Entry

> Changed - Bump WordPress "tested up to" version 6.7.

### Credits
Props @colinswinney 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
