### PR TITLE
Revert changes done in #216

### DIFF
--- a/safe-svg.php
+++ b/safe-svg.php
@@ -504,8 +504,7 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 				if ( is_array( $size ) ) {
 					$width  = $size[0];
 					$height = $size[1];
-				// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.Found, Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure
-				} elseif ( 'full' === $size && $dimensions = $this->svg_dimensions( $id ) ) {
+				} elseif ( 'full' === $size && $dimensions = $this->svg_dimensions( $id ) ) { // phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.Found, Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure
 					$width  = $dimensions['width'];
 					$height = $dimensions['height'];
 				} else {

--- a/safe-svg.php
+++ b/safe-svg.php
@@ -256,7 +256,7 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 				return $file;
 			}
 
-			$file_name   = isset( $file['name'] ) ? $file['name'] : '';
+			$file_name = isset( $file['name'] ) ? $file['name'] : '';
 
 			// Allow SVGs to be uploaded when this function runs.
 			add_filter( 'upload_mimes', array( $this, 'allow_svg' ) );
@@ -269,7 +269,7 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 			// This is because wp_check_filetype_and_ext() is called multiple times during the upload process.
 			add_filter( 'pre_move_uploaded_file', array( $this, 'pre_move_uploaded_file' ) );
 
-			$type        = ! empty( $wp_filetype['type'] ) ? $wp_filetype['type'] : '';
+			$type = ! empty( $wp_filetype['type'] ) ? $wp_filetype['type'] : '';
 
 			if ( 'image/svg+xml' === $type ) {
 				if ( ! $this->current_user_can_upload_svg() ) {

--- a/safe-svg.php
+++ b/safe-svg.php
@@ -444,9 +444,9 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 		 */
 		public function one_pixel_fix( $image, $attachment_id, $size, $icon ) {
 			if ( get_post_mime_type( $attachment_id ) === 'image/svg+xml' ) {
-				$dimensions = $this->get_svg_dimensions( $attachment_id, $size );
+				$dimensions = $this->svg_dimensions( $attachment_id, $size );
 
-				if ( is_array( $dimensions ) && isset( $dimensions['height'], $dimensions['width'] ) ) {
+				if ( $dimensions ) {
 					$image[1] = $dimensions['width'];
 					$image[2] = $dimensions['height'];
 				} else {
@@ -499,12 +499,23 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 		 */
 		public function get_image_tag_override( $html, $id, $alt, $title, $align, $size ) {
 			$mime = get_post_mime_type( $id );
-			if ( 'image/svg+xml' === $mime ) {
-				$dimensions = $this->get_svg_dimensions( $id, $size );
 
-				if ( is_array( $dimensions ) && isset( $dimensions['height'], $dimensions['width'] ) ) {
-					$html = str_replace( 'width="1" ', sprintf( 'width="%s" ', $dimensions['width'] ), $html );
-					$html = str_replace( 'height="1" ', sprintf( 'height="%s" ', $dimensions['height'] ), $html );
+			if ( 'image/svg+xml' === $mime ) {
+				if ( is_array( $size ) ) {
+					$width  = $size[0];
+					$height = $size[1];
+				// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.Found, Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure
+				} elseif ( 'full' === $size && $dimensions = $this->svg_dimensions( $id ) ) {
+					$width  = $dimensions['width'];
+					$height = $dimensions['height'];
+				} else {
+					$width  = get_option( "{$size}_size_w", false );
+					$height = get_option( "{$size}_size_h", false );
+				}
+
+				if ( $height && $width ) {
+					$html = str_replace( 'width="1" ', sprintf( 'width="%s" ', $width ), $html );
+					$html = str_replace( 'height="1" ', sprintf( 'height="%s" ', $height ), $html );
 				} else {
 					$html = str_replace( 'width="1" ', '', $html );
 					$html = str_replace( 'height="1" ', '', $html );
@@ -764,37 +775,6 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 
 			$len = strlen( $needle );
 			return 0 === substr_compare( $haystack, $needle, -$len, $len );
-		}
-
-		/**
-		 * Return custom width or height of the SVG image.
-		 *
-		 * @param int          $id   Image attachment ID.
-		 * @param string|array $size Size of image. Image size or array of width and height values
-		 *                                    (in that order). Default 'thumbnail'.
-		 *
-		 * @return array|bool Width or height of the SVG image, or false if not found.
-		 */
-		protected function get_svg_dimensions( $id, $size ) {
-			$dimensions = $this->svg_dimensions( $id );
-
-			if ( is_array( $size ) ) {
-				$width  = $size[0];
-				$height = $size[1];
-			} elseif ( 'full' === $size && is_array( $dimensions ) && isset( $dimensions['width'], $dimensions['height'] ) ) {
-				$width  = $dimensions['width'];
-				$height = $dimensions['height'];
-			} else {
-				$width  = get_option( "{$size}_size_w", false );
-				$height = get_option( "{$size}_size_h", false );
-			}
-
-			if ( $dimensions ) {
-				$dimensions['width']  = $width;
-				$dimensions['height'] = $height;
-			}
-
-			return $dimensions;
 		}
 	}
 }

--- a/tests/cypress/e2e/safe-svg.cy.js
+++ b/tests/cypress/e2e/safe-svg.cy.js
@@ -16,21 +16,21 @@ describe('Safe SVG Tests', () => {
   });
 
   it('Admin can add SVG block to a post', () => {
-	cy.uploadMedia('.wordpress-org/icon.svg');
+    cy.uploadMedia('.wordpress-org/icon.svg');
 
-	cy.createPost( {
-		title: 'SVG Block Test',
-		beforeSave: () => {
-			cy.insertBlock( 'safe-svg/svg-icon' );
-			cy.getBlockEditor().find( '.block-editor-media-placeholder' ).contains( 'button', 'Media Library' ).click();
-			cy.get( '#menu-item-browse' ).click();
-			cy.get( '.attachments-wrapper li:first .thumbnail' ).click();
-			cy.get( '.media-modal .media-button-select' ).click();
-		},
-	} ).then( post => {
-		cy.visit( `/wp-admin/post.php?post=${post.id}&action=edit` );
-		cy.getBlockEditor().find( '.wp-block-safe-svg-svg-icon' );
-	} );
+    cy.createPost( {
+        title: 'SVG Block Test',
+        beforeSave: () => {
+            cy.insertBlock( 'safe-svg/svg-icon' );
+            cy.getBlockEditor().find( '.block-editor-media-placeholder' ).contains( 'button', 'Media Library' ).click();
+            cy.get( '#menu-item-browse' ).click();
+            cy.get( '.attachments-wrapper li:first .thumbnail' ).click();
+            cy.get( '.media-modal .media-button-select' ).click();
+        },
+    } ).then( post => {
+        cy.visit( `/wp-admin/post.php?post=${post.id}&action=edit` );
+        cy.getBlockEditor().find( '.wp-block-safe-svg-svg-icon' );
+    } );
   } );
 
   /**
@@ -49,8 +49,8 @@ describe('Safe SVG Tests', () => {
     // Test
     cy.uploadMedia('tests/cypress/fixtures/custom.svg');
     cy.get('#media-items .media-item a.edit-attachment').invoke('attr', 'href').then(editLink => {
-			cy.visit(editLink);
-		} );
+            cy.visit(editLink);
+        } );
     cy.get('input#attachment_url').invoke('val')
       .then(url => {
         cy.request(url)
@@ -74,8 +74,8 @@ describe('Safe SVG Tests', () => {
     cy.uploadMedia('tests/cypress/fixtures/custom.svg');
 
     cy.get('#media-items .media-item a.edit-attachment').invoke('attr', 'href').then(editLink => {
-			cy.visit( editLink );
-		});
+            cy.visit( editLink );
+        });
     cy.get('input#attachment_url').invoke('val')
       .then(url => {
         cy.request(url)
@@ -110,36 +110,36 @@ describe('Safe SVG Tests', () => {
     // Activate test plugin.
     cy.activatePlugin('safe-svg-cypress-test-plugin');
 
-	// Visit the home page.
+    // Visit the home page.
     cy.visit('/');
 
-	// Verify that the SVG images are displayed with the correct dimensions.
-	cy.get('#thumbnail-image').should('have.attr', 'width', '256').should('have.attr', 'height', '256');
-	cy.get('#medium-image').should('have.attr', 'width', '256').should('have.attr', 'height', '256');
-	cy.get('#large-image').should('have.attr', 'width', '256').should('have.attr', 'height', '256');
-	cy.get('#full-image').should('have.attr', 'width', '256').should('have.attr', 'height', '256');
-	cy.get('#custom-image').should('have.attr', 'width', '256').should('have.attr', 'height', '256');
+    // Verify that the SVG images are displayed with the correct dimensions.
+    cy.get('#thumbnail-image').should('have.attr', 'width', '256').should('have.attr', 'height', '256');
+    cy.get('#medium-image').should('have.attr', 'width', '256').should('have.attr', 'height', '256');
+    cy.get('#large-image').should('have.attr', 'width', '256').should('have.attr', 'height', '256');
+    cy.get('#full-image').should('have.attr', 'width', '256').should('have.attr', 'height', '256');
+    cy.get('#custom-image').should('have.attr', 'width', '256').should('have.attr', 'height', '256');
 
-	// Deactivate the test plugin.
-	cy.deactivatePlugin('safe-svg-cypress-test-plugin');
+    // Deactivate the test plugin.
+    cy.deactivatePlugin('safe-svg-cypress-test-plugin');
   });
 
   it('Output of get_image_tag should use custom dimensions', () => {
     // Activate test plugin.
     cy.activatePlugin('safe-svg-cypress-test-plugin');
 
-	// Visit the home page.
+    // Visit the home page.
     cy.visit('/');
 
-	// Verify that the SVG images are displayed with the correct dimensions.
-	// TODO: these are the sizes returned but seems they are not correct. get_image_tag_override needs to be fixed.
-	cy.get('.size-thumbnail.wp-image-6').should('have.attr', 'width', '150').should('have.attr', 'height', '150');
-	cy.get('.size-medium.wp-image-6').should('have.attr', 'width', '300').should('have.attr', 'height', '300');
-	cy.get('.size-large.wp-image-6').should('have.attr', 'width', '1024').should('have.attr', 'height', '1024');
-	cy.get('.size-full.wp-image-6').should('have.attr', 'width', '256').should('have.attr', 'height', '256');
-	cy.get('.size-100x120.wp-image-6').should('have.attr', 'width', '100').should('have.attr', 'height', '100');
+    // Verify that the SVG images are displayed with the correct dimensions.
+    // TODO: these are the sizes returned but seems they are not correct. get_image_tag_override needs to be fixed.
+    cy.get('.size-thumbnail.wp-image-6').should('have.attr', 'width', '150').should('have.attr', 'height', '150');
+    cy.get('.size-medium.wp-image-6').should('have.attr', 'width', '300').should('have.attr', 'height', '300');
+    cy.get('.size-large.wp-image-6').should('have.attr', 'width', '1024').should('have.attr', 'height', '1024');
+    cy.get('.size-full.wp-image-6').should('have.attr', 'width', '256').should('have.attr', 'height', '256');
+    cy.get('.size-100x120.wp-image-6').should('have.attr', 'width', '100').should('have.attr', 'height', '100');
 
-	// Deactivate the test plugin.
-	cy.deactivatePlugin('safe-svg-cypress-test-plugin');
+    // Deactivate the test plugin.
+    cy.deactivatePlugin('safe-svg-cypress-test-plugin');
   });
 });

--- a/tests/cypress/e2e/safe-svg.cy.js
+++ b/tests/cypress/e2e/safe-svg.cy.js
@@ -105,4 +105,41 @@ describe('Safe SVG Tests', () => {
     cy.activatePlugin('safe-svg-cypress-optimizer-test-plugin');
     cy.createPost('Hello World');
   });
+
+  it('Output of wp_get_attachment_image should use full svg dimensions', () => {
+    // Activate test plugin.
+    cy.activatePlugin('safe-svg-cypress-test-plugin');
+
+	// Visit the home page.
+    cy.visit('/');
+
+	// Verify that the SVG images are displayed with the correct dimensions.
+	cy.get('#thumbnail-image').should('have.attr', 'width', '256').should('have.attr', 'height', '256');
+	cy.get('#medium-image').should('have.attr', 'width', '256').should('have.attr', 'height', '256');
+	cy.get('#large-image').should('have.attr', 'width', '256').should('have.attr', 'height', '256');
+	cy.get('#full-image').should('have.attr', 'width', '256').should('have.attr', 'height', '256');
+	cy.get('#custom-image').should('have.attr', 'width', '256').should('have.attr', 'height', '256');
+
+	// Deactivate the test plugin.
+	cy.deactivatePlugin('safe-svg-cypress-test-plugin');
+  });
+
+  it('Output of get_image_tag should use custom dimensions', () => {
+    // Activate test plugin.
+    cy.activatePlugin('safe-svg-cypress-test-plugin');
+
+	// Visit the home page.
+    cy.visit('/');
+
+	// Verify that the SVG images are displayed with the correct dimensions.
+	// TODO: these are the sizes returned but seems they are not correct. get_image_tag_override needs to be fixed.
+	cy.get('.size-thumbnail.wp-image-6').should('have.attr', 'width', '150').should('have.attr', 'height', '150');
+	cy.get('.size-medium.wp-image-6').should('have.attr', 'width', '300').should('have.attr', 'height', '300');
+	cy.get('.size-large.wp-image-6').should('have.attr', 'width', '1024').should('have.attr', 'height', '1024');
+	cy.get('.size-full.wp-image-6').should('have.attr', 'width', '256').should('have.attr', 'height', '256');
+	cy.get('.size-100x120.wp-image-6').should('have.attr', 'width', '100').should('have.attr', 'height', '100');
+
+	// Deactivate the test plugin.
+	cy.deactivatePlugin('safe-svg-cypress-test-plugin');
+  });
 });

--- a/tests/cypress/test-plugin/e2e-test-plugin.php
+++ b/tests/cypress/test-plugin/e2e-test-plugin.php
@@ -21,3 +21,19 @@ add_filter(
 		return $tags;
 	}
 );
+
+add_action(
+	'wp_body_open',
+	function () {
+		echo wp_get_attachment_image( 6, 'thumbnail', false, [ 'id' => 'thumbnail-image' ] );
+		echo wp_get_attachment_image( 6, 'medium', false, [ 'id' => 'medium-image' ] );
+		echo wp_get_attachment_image( 6, 'large', false, [ 'id' => 'large-image' ] );
+		echo wp_get_attachment_image( 6, 'full', false, [ 'id' => 'full-image' ] );
+		echo wp_get_attachment_image( 6, [ 100, 120 ], false, [ 'id' => 'custom-image' ] );
+		echo get_image_tag( 6, '', '', '', 'thumbnail' );
+		echo get_image_tag( 6, '', '', '', 'medium' );
+		echo get_image_tag( 6, '', '', '', 'large' );
+		echo get_image_tag( 6, '', '', '', 'full' );
+		echo get_image_tag( 6, '', '', '', [ 100, 120 ] );
+	}
+);

--- a/tests/unit/test-safe-svg.php
+++ b/tests/unit/test-safe-svg.php
@@ -275,7 +275,7 @@ class SafeSvgTest extends TestCase {
 		);
 
 		// Test SVG Dimensions
-		$image_sizes = $this->instance->one_pixel_fix( array(), 1, 'full', false );
+		$image_sizes = $this->instance->one_pixel_fix( array(), 1, 'thumbnail', false );
 		if ( ! empty( $image_sizes ) ) {
 			$image_sizes = array_map( 'intval', $image_sizes );
 		}
@@ -307,8 +307,8 @@ class SafeSvgTest extends TestCase {
 		}
 		$this->assertSame(
 			array(
-				1 => 500,
-				2 => 500,
+				1 => 600,
+				2 => 600,
 			),
 			$image_sizes
 		);


### PR DESCRIPTION
### Description of the Change

As reported in #237, the changes made in #216 are causing issues for anyone using the `wp_get_attachment_image` function to output SVGs. As described in that Issue, we need to be smarter in how we determine the height and width attributes to use instead of just relying on the dimensions for each registered size (since SVGs don't get cropped the same as normal images by WordPress).

This PR reverts the changes introduced in #216 and also adds some additional E2E tests to help us catch these sorts of issues in the future.

Note there is additional work we could look to do here, both fixing what we were attempting to do in #216 and being smarter with how we determine the SVG sizes, as described in this [comment](https://github.com/10up/safe-svg/issues/237#issuecomment-2514800549).

Closes #237

### How to test the Change

1. Ensure general functionality of the plugin still works as expected (you can upload svgs, you can add those into content, etc)
2. Also modify your theme to directly output svgs using `wp_get_attachment_image` and ensure that no matter what image size you pass in, the full SVG dimensions are used instead (which is previous behavior)

### Changelog Entry

> Fixed - Revert changes made to how we determine custom dimensions for svgs

### Credits

Props @dkotter, @martinpl, @subfighter3, @smerriman, @gigatyrant

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
