### PR TITLE
Add the ability to upload SVGs when creating new terms and editing terms

### DIFF
--- a/safe-svg.php
+++ b/safe-svg.php
@@ -133,6 +133,7 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 			add_action( 'load-post-new.php', array( $this, 'allow_svg_from_upload' ) );
 			add_action( 'load-post.php', array( $this, 'allow_svg_from_upload' ) );
 			add_action( 'load-site-editor.php', array( $this, 'allow_svg_from_upload' ) );
+			add_action( 'load-edit-tags.php', array( $this, 'allow_svg_from_upload' ) );
 
 			// Init all the things.
 			add_action( 'init', array( $this, 'setup_blocks' ) );


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Add the ability to upload SVGs on terms. I've tested it on adding new terms and updating existing terms.

The use case is the ability to upload an SVG to a term with a custom field to add media. In my instance, I need to upload icons associated with each term.

<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Add a media upload field for terms.
2. Attempt to upload an SVG on the edit-tags.php page.
3. Attempt to upload an SVG on the term.php page.

I don't think new tests are needed, but let me know if you feel differently.



### Changelog Entry
Added - Ability to upload SVGs on taxonomy term pages.

<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
> Developer - Non-functional update

### Credits
Just me 😅  @stormrockwell

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.

I am getting a cypress error (on develop as well)
```
 Admin can add SVG block to a post:
     AssertionError: Timed out retrying after 4000ms: Expected to find element: `.block-editor-media-placeholder`, but never found it. Queried from:

              > <body.block-editor-iframe__body.editor-styles-wrapper.post-type-post.admin-color-fresh.wp-embed-responsive>
```
