### PR TITLE
Bump: "Tested up to" WP 6.8

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Safe SVG ===
 Contributors:      10up, enshrined, jeffpaul
 Tags:              svg, security, media, vector, mime
-Tested up to:      6.7
+Tested up to:      6.8
 Stable tag:        2.3.1
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html


### PR DESCRIPTION
### Description of the Change

Updates WordPress "Tested Up To" version to 6.8.
![image1](https://github.com/user-attachments/assets/ac3918e3-6de9-417e-9363-9908dbab3744)
![image2](https://github.com/user-attachments/assets/ba861805-9c9d-43f3-9451-7e037960eec0)
![image3](https://github.com/user-attachments/assets/7a602c2f-63c9-490f-961f-4b1534c13b57)

Closes #249

### Changelog Entry
> Developer - Bump WordPress "tested up to" version 6.8.

### Credits
Props @godleman 


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.