### PR TITLE
Add icon fill color support

### DIFF
--- a/includes/blocks/safe-svg/block.json
+++ b/includes/blocks/safe-svg/block.json
@@ -47,7 +47,7 @@
   "supports": {
     "html": false,
     "color": {
-      "text": true,
+      "text": false,
       "background": true
     },
     "spacing": {

--- a/includes/blocks/safe-svg/block.json
+++ b/includes/blocks/safe-svg/block.json
@@ -36,6 +36,12 @@
     },
     "imageSizes": {
       "type": "object"
+    },
+    "iconColor": {
+      "type": "string"
+    },
+    "iconColorValue": {
+      "type": "string"
     }
   },
   "supports": {

--- a/includes/blocks/safe-svg/edit.js
+++ b/includes/blocks/safe-svg/edit.js
@@ -31,7 +31,7 @@ import { ReactSVG } from 'react-svg'
  * @param {Function} props.setAttributes        Sets the value for block attributes.
  * @return {Function} Render the edit screen
  */
-const SafeSvgBlockEdit = ( props ) => {
+const SafeSvgBlockEdit = (props) => {
 	const { attributes, setAttributes } = props;
 
 	const {
@@ -48,7 +48,7 @@ const SafeSvgBlockEdit = ( props ) => {
 	} = attributes;
 	const blockProps = useBlockProps(
 		{
-			className:` wp-block-safe-svg-svg-icon safe-svg-cover`,
+			className: ` wp-block-safe-svg-svg-icon safe-svg-cover`,
 			style: {
 				textAlign: alignment,
 			}
@@ -68,20 +68,20 @@ const SafeSvgBlockEdit = ( props ) => {
 	style.width = `${dimensionWidth}px`;
 	style.height = `${dimensionHeight}px`;
 
-	const ALLOWED_MEDIA_TYPES = [ 'image/svg+xml' ];
+	const ALLOWED_MEDIA_TYPES = ['image/svg+xml'];
 
 	const onSelectImage = media => {
-		if ( !media.sizes && !media.media_details?.sizes ) {
+		if (!media.sizes && !media.media_details?.sizes) {
 			return;
 		}
 
-		if( media.media_details ) {
+		if (media.media_details) {
 			media.sizes = media.media_details.sizes;
 		}
 
 		const newURL = media.sizes.full.url ?? media.sizes.full.source_url;
 
-		setAttributes( {
+		setAttributes({
 			imageSizes: {
 				full: media.sizes.full,
 				medium: media.sizes.medium,
@@ -94,17 +94,17 @@ const SafeSvgBlockEdit = ( props ) => {
 			imageID: media.id,
 			svgURL: newURL,
 			type: 'full',
-		} );
+		});
 	};
 
-	const onError = ( message ) => {
-		console.log( __(`Something went wrong, please try again. Message: ${message}`, 'safe-svg') );
+	const onError = (message) => {
+		console.log(__(`Something went wrong, please try again. Message: ${message}`, 'safe-svg'));
 	}
 
 	const onChange = (dimensionSizes) => {
-		if( !dimensionSizes.width && !dimensionSizes.height ) {
-			dimensionSizes.width = parseInt( imageSizes[type].width );
-			dimensionSizes.height = parseInt( imageSizes[type].height );
+		if (!dimensionSizes.width && !dimensionSizes.height) {
+			dimensionSizes.width = parseInt(imageSizes[type].width);
+			dimensionSizes.height = parseInt(imageSizes[type].height);
 		}
 		setAttributes({
 			dimensionWidth: dimensionSizes.width ?? dimensionWidth,
@@ -114,13 +114,13 @@ const SafeSvgBlockEdit = ( props ) => {
 
 	const onChangeImage = (newSizeSlug) => {
 		const newUrl = imageSizes[newSizeSlug].url ?? imageSizes[newSizeSlug].source_url;
-		if( ! newUrl ) {
+		if (!newUrl) {
 			return null;
 		}
-		let newWidth = parseInt( imageSizes[newSizeSlug].width );
-		let newHeight = parseInt( imageSizes[newSizeSlug].height );
-		if( 'full' !== newSizeSlug ) {
-			if(imageSizes[newSizeSlug].width >= imageSizes[newSizeSlug].height) {
+		let newWidth = parseInt(imageSizes[newSizeSlug].width);
+		let newHeight = parseInt(imageSizes[newSizeSlug].height);
+		if ('full' !== newSizeSlug) {
+			if (imageSizes[newSizeSlug].width >= imageSizes[newSizeSlug].height) {
 				newHeight = imageSizes[newSizeSlug].height * imageSizes['full'].height / imageSizes['full'].width;
 			} else {
 				newWidth = imageSizes[newSizeSlug].width * imageSizes['full'].width / imageSizes['full'].height;
@@ -145,28 +145,31 @@ const SafeSvgBlockEdit = ( props ) => {
 	return (
 		<>
 			{svgURL &&
-				<><InspectorControls>
-					<PanelBody
-						title={__(
-							'Image settings',
-							'safe-svg'
-						)}
-					>
-						<ImageSizeControl
-							width={dimensionWidth}
-							height={dimensionHeight}
-							imageWidth={imageWidth}
-							imageHeight={imageHeight}
-							imageSizeOptions={imageSizeOptions}
-							slug={type}
-							onChange={onChange}
-							onChangeImage={onChangeImage} />
-					</PanelBody>
-				</InspectorControls><BlockControls>
+				<>
+					<InspectorControls>
+						<PanelBody
+							title={__(
+								'Image settings',
+								'safe-svg'
+							)}
+						>
+							<ImageSizeControl
+								width={dimensionWidth}
+								height={dimensionHeight}
+								imageWidth={imageWidth}
+								imageHeight={imageHeight}
+								imageSizeOptions={imageSizeOptions}
+								slug={type}
+								onChange={onChange}
+								onChangeImage={onChangeImage} />
+						</PanelBody>
+					</InspectorControls>
+					<BlockControls>
 						<AlignmentToolbar
 							value={alignment}
 							onChange={(newVal) => setAttributes({ alignment: newVal })} />
-					</BlockControls><BlockControls>
+					</BlockControls>
+					<BlockControls>
 						<MediaReplaceFlow
 							mediaId={imageID}
 							mediaURL={svgURL}
@@ -174,48 +177,48 @@ const SafeSvgBlockEdit = ( props ) => {
 							accept={ALLOWED_MEDIA_TYPES}
 							onSelect={onSelectImage}
 							onError={onError} />
-					</BlockControls></>
+					</BlockControls>
+				</>
 			}
-
 
 			{!svgURL &&
 				<MediaPlaceholder
 					onSelect={onSelectImage}
-					allowedTypes = {ALLOWED_MEDIA_TYPES}
+					allowedTypes={ALLOWED_MEDIA_TYPES}
 					accept={ALLOWED_MEDIA_TYPES}
 					value={imageID}
 					labels={{
-						title: __( 'Inline SVG', 'safe-svg' ),
-						instructions: __( 'Upload an SVG or pick one from your media library.', 'safe-svg' )
+						title: __('Inline SVG', 'safe-svg'),
+						instructions: __('Upload an SVG or pick one from your media library.', 'safe-svg')
 					}}
 				/>
 			}
 
 			{svgURL &&
-				<div { ...containerBlockProps }>
+				<div {...containerBlockProps}>
 					<div
 						style={style}
 						className="safe-svg-inside"
 					>
 						<ReactSVG src={svgURL} beforeInjection={(svg) => {
-							svg.setAttribute( 'style', `width: ${dimensionWidth}px; height: ${dimensionHeight}px;` );
+							svg.setAttribute('style', `width: ${dimensionWidth}px; height: ${dimensionHeight}px;`);
 						}} />
 					</div>
 				</div>
 			}
 
-			{ contentPostType && (
+			{contentPostType && (
 				<Placeholder
-					label={ __( 'SafeSvg', 'safe-svg' ) }
+					label={__('SafeSvg', 'safe-svg')}
 				>
 					<p>
-						{ __(
+						{__(
 							'Please select the SVG icon.',
 							'safe-svg'
-						) }
+						)}
 					</p>
 				</Placeholder>
-			) }
+			)}
 		</>
 	);
 };

--- a/includes/blocks/safe-svg/edit.js
+++ b/includes/blocks/safe-svg/edit.js
@@ -1,5 +1,12 @@
 /* eslint-disable no-unused-vars */
 /**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { ReactSVG } from 'react-svg'
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -14,10 +21,11 @@ import {
 	InspectorControls,
 	__experimentalImageSizeControl as ImageSizeControl,
 	MediaReplaceFlow,
-	MediaPlaceholder
+	MediaPlaceholder,
+	withColors,
+	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
+	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
 } from '@wordpress/block-editor';
-import PropTypes from 'prop-types';
-import { ReactSVG } from 'react-svg'
 
 /**
  * Edit component.
@@ -32,7 +40,13 @@ import { ReactSVG } from 'react-svg'
  * @return {Function} Render the edit screen
  */
 const SafeSvgBlockEdit = (props) => {
-	const { attributes, setAttributes } = props;
+	const {
+		clientId,
+		attributes,
+		setAttributes,
+		iconColor,
+		setIconColor,
+	} = props;
 
 	const {
 		contentPostType,
@@ -44,14 +58,23 @@ const SafeSvgBlockEdit = (props) => {
 		imageWidth,
 		imageHeight,
 		dimensionWidth,
-		dimensionHeight
+		dimensionHeight,
+		iconColorValue,
 	} = attributes;
+
+	const iconClasses = classnames('wp-block-safe-svg-svg-icon', 'safe-svg-cover', {
+		'has-icon-color': iconColor.color || iconColorValue,
+	});
+
+	const iconStyles = {
+		textAlign: alignment,
+		color: iconColorValue,
+	};
+
 	const blockProps = useBlockProps(
 		{
-			className: ` wp-block-safe-svg-svg-icon safe-svg-cover`,
-			style: {
-				textAlign: alignment,
-			}
+			className: iconClasses,
+			style: iconStyles
 		}
 	);
 
@@ -149,6 +172,23 @@ const SafeSvgBlockEdit = (props) => {
 		},
 	];
 
+	const colorSettings = [
+		{
+			value: iconColor.color || iconColorValue,
+			onChange: (colorValue) => {
+				setIconColor(colorValue);
+				setAttributes({ iconColorValue: colorValue });
+			},
+			label: __('Icon color', 'safe-svg'),
+			resetAllFilter: () => {
+				setIconColor(undefined);
+				setAttributes({ iconColorValue: undefined });
+			},
+		},
+	];
+
+	const colorGradientSettings = useMultipleOriginColorsAndGradients();
+
 	return (
 		<>
 			{svgURL &&
@@ -171,6 +211,31 @@ const SafeSvgBlockEdit = (props) => {
 								onChangeImage={onChangeImage} />
 						</PanelBody>
 					</InspectorControls>
+					{colorGradientSettings.hasColorsOrGradients && (
+						<InspectorControls group="color">
+							{colorSettings.map(
+								({ onChange, label, value, resetAllFilter }) => (
+									<ColorGradientSettingsDropdown
+										key={`wp-block-safe-svg-color-${label}`}
+										__experimentalIsRenderedInSidebar
+										settings={[
+											{
+												colorValue: value,
+												label,
+												onColorChange: onChange,
+												isShownByDefault: true,
+												resetAllFilter,
+												enableAlpha: true,
+												clearable: true,
+											},
+										]}
+										panelId={clientId}
+										{...colorGradientSettings}
+									/>
+								)
+							)}
+						</InspectorControls>
+					)}
 					<BlockControls>
 						<AlignmentToolbar
 							value={alignment}
@@ -246,4 +311,8 @@ SafeSvgBlockEdit.propTypes = {
 	setAttributes: PropTypes.func.isRequired,
 };
 
-export default SafeSvgBlockEdit;
+const iconColorAttributes = {
+	iconColor: 'icon-color',
+};
+
+export default withColors(iconColorAttributes)(SafeSvgBlockEdit);

--- a/includes/blocks/safe-svg/edit.js
+++ b/includes/blocks/safe-svg/edit.js
@@ -54,6 +54,7 @@ const SafeSvgBlockEdit = (props) => {
 			}
 		}
 	);
+
 	const { className, style, ...containerBlockProps } = blockProps;
 
 	// Remove text alignment so we can apply to the parent container.
@@ -137,9 +138,15 @@ const SafeSvgBlockEdit = (props) => {
 	}
 
 	const imageSizeOptions = [
-		{ value: 'full', label: 'Full Size' },
-		{ value: 'medium', label: 'Medium' },
-		{ value: 'thumbnail', label: 'Thumbnail' },
+		{
+			value: 'full', label: __('Full Size', 'safe-svg')
+		},
+		{
+			value: 'medium', label: __('Medium', 'safe-svg')
+		},
+		{
+			value: 'thumbnail', label: __('Thumbnail', 'safe-svg')
+		},
 	];
 
 	return (

--- a/includes/blocks/safe-svg/frontend.scss
+++ b/includes/blocks/safe-svg/frontend.scss
@@ -7,6 +7,7 @@
     }
 
     svg {
+        fill: currentColor;
         height: 100%;
         max-height: 100%;
         max-width: 100%;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.3.1",
       "license": "GPL-2.0-or-later",
       "dependencies": {
+        "classnames": "^2.5.1",
         "react-svg": "^16.1.18",
         "svgo": "^3.0.2"
       },
@@ -7451,6 +7452,12 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "dev": true
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "mochawesome-json-to-md": "^0.7.2"
   },
   "dependencies": {
+    "classnames": "^2.5.1",
     "react-svg": "^16.1.18",
     "svgo": "^3.0.2"
   }


### PR DESCRIPTION
### Description of the Change
This PR adds a new "Icon color" setting, allowing editors to control the SVG fill color. It also removes text color support, as it's redundant in this icon-specific context.

Before

<img width="590" alt="Screenshot 2025-06-28 at 17 31 02" src="https://github.com/user-attachments/assets/e4226c42-f568-4255-9243-21ccaaaaec65" />

After

<img width="643" alt="Screenshot 2025-06-28 at 17 31 30" src="https://github.com/user-attachments/assets/25a660ec-aea2-4a31-a542-d34dda553819" />

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - fillColor support with Icon color settings

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @s3rgiosan

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
