### PR TITLE
Revert to use text color and apply editor color class for parity

### DIFF
--- a/includes/blocks/safe-svg/block.json
+++ b/includes/blocks/safe-svg/block.json
@@ -36,18 +36,12 @@
     },
     "imageSizes": {
       "type": "object"
-    },
-    "iconColor": {
-      "type": "string"
-    },
-    "iconColorValue": {
-      "type": "string"
     }
   },
   "supports": {
     "html": false,
     "color": {
-      "text": false,
+      "text": true,
       "background": true
     },
     "spacing": {

--- a/includes/blocks/safe-svg/edit.js
+++ b/includes/blocks/safe-svg/edit.js
@@ -22,9 +22,7 @@ import {
 	__experimentalImageSizeControl as ImageSizeControl,
 	MediaReplaceFlow,
 	MediaPlaceholder,
-	withColors,
-	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
-	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
+	getColorClassName,
 } from '@wordpress/block-editor';
 
 /**
@@ -39,14 +37,7 @@ import {
  * @param {Function} props.setAttributes        Sets the value for block attributes.
  * @return {Function} Render the edit screen
  */
-const SafeSvgBlockEdit = (props) => {
-	const {
-		clientId,
-		attributes,
-		setAttributes,
-		iconColor,
-		setIconColor,
-	} = props;
+const SafeSvgBlockEdit = ({ attributes, setAttributes }) => {
 
 	const {
 		contentPostType,
@@ -59,22 +50,15 @@ const SafeSvgBlockEdit = (props) => {
 		imageHeight,
 		dimensionWidth,
 		dimensionHeight,
-		iconColorValue,
+		textColor,
 	} = attributes;
-
-	const iconClasses = classnames('wp-block-safe-svg-svg-icon', 'safe-svg-cover', {
-		'has-icon-color': iconColor.color || iconColorValue,
-	});
-
-	const iconStyles = {
-		textAlign: alignment,
-		color: iconColorValue,
-	};
 
 	const blockProps = useBlockProps(
 		{
-			className: iconClasses,
-			style: iconStyles
+			className: 'wp-block-safe-svg-svg-icon safe-svg-cover',
+			style: {
+				textAlign: alignment,
+			}
 		}
 	);
 
@@ -172,23 +156,6 @@ const SafeSvgBlockEdit = (props) => {
 		},
 	];
 
-	const colorSettings = [
-		{
-			value: iconColor.color || iconColorValue,
-			onChange: (colorValue) => {
-				setIconColor(colorValue);
-				setAttributes({ iconColorValue: colorValue });
-			},
-			label: __('Icon color', 'safe-svg'),
-			resetAllFilter: () => {
-				setIconColor(undefined);
-				setAttributes({ iconColorValue: undefined });
-			},
-		},
-	];
-
-	const colorGradientSettings = useMultipleOriginColorsAndGradients();
-
 	return (
 		<>
 			{svgURL &&
@@ -211,31 +178,6 @@ const SafeSvgBlockEdit = (props) => {
 								onChangeImage={onChangeImage} />
 						</PanelBody>
 					</InspectorControls>
-					{colorGradientSettings.hasColorsOrGradients && (
-						<InspectorControls group="color">
-							{colorSettings.map(
-								({ onChange, label, value, resetAllFilter }) => (
-									<ColorGradientSettingsDropdown
-										key={`wp-block-safe-svg-color-${label}`}
-										__experimentalIsRenderedInSidebar
-										settings={[
-											{
-												colorValue: value,
-												label,
-												onColorChange: onChange,
-												isShownByDefault: true,
-												resetAllFilter,
-												enableAlpha: true,
-												clearable: true,
-											},
-										]}
-										panelId={clientId}
-										{...colorGradientSettings}
-									/>
-								)
-							)}
-						</InspectorControls>
-					)}
 					<BlockControls>
 						<AlignmentToolbar
 							value={alignment}
@@ -270,7 +212,10 @@ const SafeSvgBlockEdit = (props) => {
 				<div {...containerBlockProps}>
 					<div
 						style={style}
-						className="safe-svg-inside"
+						className={classnames(
+							'safe-svg-inside',
+							getColorClassName('color', textColor) || ''
+						)}
 					>
 						<ReactSVG src={svgURL} beforeInjection={(svg) => {
 							svg.setAttribute('style', `width: ${dimensionWidth}px; height: ${dimensionHeight}px;`);
@@ -311,8 +256,4 @@ SafeSvgBlockEdit.propTypes = {
 	setAttributes: PropTypes.func.isRequired,
 };
 
-const iconColorAttributes = {
-	iconColor: 'icon-color',
-};
-
-export default withColors(iconColorAttributes)(SafeSvgBlockEdit);
+export default SafeSvgBlockEdit;

--- a/includes/blocks/safe-svg/register.php
+++ b/includes/blocks/safe-svg/register.php
@@ -67,8 +67,8 @@ function render_block_callback( $attributes ) {
 	return apply_filters(
 		'safe_svg_inline_markup',
 		sprintf(
-			'<div class="wp-block-safe-svg-svg-icon safe-svg-cover" style="text-align: %s;">
-				<div class="safe-svg-inside %s%s" style="width: %spx; height: %spx; background-color: var(--wp--preset--color--%s); color: var(--wp--preset--color--%s); padding-top: %s; padding-right: %s; padding-bottom: %s; padding-left: %s; margin-top: %s; margin-right: %s; margin-bottom: %s; margin-left: %s;">%s</div>
+			'<div class="wp-block-safe-svg-svg-icon safe-svg-cover" style="text-align: %1$s;">
+				<div class="safe-svg-inside %2$s%3$s" style="width: %4$spx; height: %5$spx; background-color: var(--wp--preset--color--%6$s); color: var(--wp--preset--color--%7$s); padding-top: %8$s; padding-right: %9$s; padding-bottom: %10$s; padding-left: %11$s; margin-top: %12$s; margin-right: %13$s; margin-bottom: %14$s; margin-left: %15$s;">%16$s</div>
 			</div>',
 			isset( $attributes['alignment'] ) ? esc_attr( $attributes['alignment'] ) : 'left',
 			esc_attr( $class_name ),


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

This PR reverts icon color usage to use the text color UI for backwards compatibility. It also applies the correct color class name in the editor to ensure parity between the front end and the block editor.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/safe-svg/pull/261#issuecomment-3074324705

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> ~~Added - fillColor support with Icon color settings~~
> Fixed - Visual parity between the front end and the block editor

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @s3rgiosan

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
