### PR TITLE
Configure dependabot to automatically create PR for enshrined/svg-sanitize

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  # Enable version updates for enshrined/svg-sanitize package only
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    target-branch: "develop"
+    commit-message:
+      prefix: "composer"
+      include: "scope"
+    # Only update the specific enshrined/svg-sanitize package
+    allow:
+      - dependency-name: "enshrined/svg-sanitize"
+    # Open pull requests for version updates against the develop branch
+    open-pull-requests-limit: 5
+    # Allow up to 5 open pull requests for version updates
+    update-types:
+      - "minor"
+      - "patch" 


### PR DESCRIPTION
### Description of the Change

Configure dependabot to automatically create PR for enshrined/svg-sanitize

Closes #246 

### Changelog Entry
Developer - Configure dependabot to automatically create PR for enshrined/svg-sanitize

### Credits
Props @sudar 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
