### PR TITLE
Bump svg sanitization library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	],
 	"require": {
 		"php": ">=7.4",
-		"enshrined/svg-sanitize": "^0.21.0"
+		"enshrined/svg-sanitize": "^0.22.0"
 	},
 	"require-dev": {
 		"10up/phpcs-composer": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "19357959cf131d6e34a4e1ac3c4dbe5a",
+    "content-hash": "b11636263ada0d11272a0b07c12577f4",
     "packages": [
         {
             "name": "enshrined/svg-sanitize",
-            "version": "0.21.0",
+            "version": "0.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/darylldoyle/svg-sanitizer.git",
-                "reference": "5e477468fac5c5ce933dce53af3e8e4e58dcccc9"
+                "reference": "0afa95ea74be155a7bcd6c6fb60c276c39984500"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/darylldoyle/svg-sanitizer/zipball/5e477468fac5c5ce933dce53af3e8e4e58dcccc9",
-                "reference": "5e477468fac5c5ce933dce53af3e8e4e58dcccc9",
+                "url": "https://api.github.com/repos/darylldoyle/svg-sanitizer/zipball/0afa95ea74be155a7bcd6c6fb60c276c39984500",
+                "reference": "0afa95ea74be155a7bcd6c6fb60c276c39984500",
                 "shasum": ""
             },
             "require": {
@@ -47,9 +47,9 @@
             "description": "An SVG sanitizer for PHP",
             "support": {
                 "issues": "https://github.com/darylldoyle/svg-sanitizer/issues",
-                "source": "https://github.com/darylldoyle/svg-sanitizer/tree/0.21.0"
+                "source": "https://github.com/darylldoyle/svg-sanitizer/tree/0.22.0"
             },
-            "time": "2025-01-13T09:32:25+00:00"
+            "time": "2025-08-12T10:13:48+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
### Description of the Change

Updated the `enshrined/svg-sanitize` package from version `^0.21.0` to `^0.22.0` in `composer.json` to use the latest release.

This updated resolves an issue where attribute name case inconsistencies (e.g., `xlink:Href` instead of `xlink:href`) in XML processing could cause namespace lookups and sanitisation to fail. Attribute names in both namespaced and non-namespaced contexts are now normalised to their expected lowercase form before processing. This ensures consistent sanitisation of `xlink:href` and other targeted attributes regardless of their original case.

### Changelog Entry

* Security - Updated the sanitisation library to fix an issue with case-insensitive attributes slipping through the sanitiser.

### Credits
@darylldoyle 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.