### PR TITLE
Refactor SVG loading and dimension handling

### DIFF
--- a/safe-svg.php
+++ b/safe-svg.php
@@ -654,14 +654,14 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 				$width  = floatval( $metadata['width'] );
 				$height = floatval( $metadata['height'] );
 			} elseif ( $svg ) {
-				$svg = @simplexml_load_file( $svg ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+				$xml = @simplexml_load_file( $svg ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 
 				// Ensure the svg could be loaded.
-				if ( ! $svg ) {
+				if ( ! $xml ) {
 					return false;
 				}
 
-				$attributes = $svg->attributes();
+				$attributes = $xml->attributes();
 
 				if ( isset( $attributes->viewBox ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 					$sizes = explode( ' ', $attributes->viewBox ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
@@ -687,10 +687,11 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 				 *
 				 * @param bool   $use_width_height_attributes If the width & height attributes should be used first. Default false.
 				 * @param string $svg                         The file path to the SVG.
+				 * @param int    $attachment_id               The attachment ID.
 				 *
 				 * @return bool If we should use the width & height attributes first or not.
 				 */
-				$use_width_height = (bool) apply_filters( 'safe_svg_use_width_height_attributes', false, $svg );
+				$use_width_height = (bool) apply_filters( 'safe_svg_use_width_height_attributes', false, $svg, $attachment_id );
 
 				if ( $use_width_height ) {
 					if ( isset( $attr_width, $attr_height ) ) {
@@ -724,12 +725,13 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 			/**
 			 * Calculate SVG dimensions and orientation.
 			 *
-			 * @param array  $dimensions An array containing width, height, and orientation.
-			 * @param string $svg        The file path to the SVG.
+			 * @param array  $dimensions    An array containing width, height, and orientation.
+			 * @param string $svg           The file path to the SVG.
+			 * @param int    $attachment_id The attachment ID.
 			 *
 			 * @return array An array of SVG dimensions and orientation.
 			 */
-			return apply_filters( 'safe_svg_dimensions', $dimensions, $svg );
+			return apply_filters( 'safe_svg_dimensions', $dimensions, $svg, $attachment_id );
 		}
 
 		/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Corrects the filters in the `svg_dimensions` method to return the documented value and data type, and additionally sends the attachment ID as the last parameter because it's more useful to do things with than the file path.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #277 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

The following snippet no longer throws a fatal error.

```php
add_filter( 'safe_svg_use_width_height_attributes', function ( bool $use_width_height, string $svg ) {
	return $use_width_height;
}, 10, 2 );
```

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Changed - Added `$attachment_id` argument to filters `safe_svg_use_width_height_attributes` and `safe_svg_dimensions`.
> Fixed - Inconsistent or incorrect data type for `$svg` argument in the filters `safe_svg_use_width_height_attributes` and `safe_svg_dimensions`.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @roborourke 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
