### PR TITLE
Allow uploads on all pages using Media JS APIs

### DIFF
--- a/safe-svg.php
+++ b/safe-svg.php
@@ -134,6 +134,18 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 			add_action( 'load-post.php', array( $this, 'allow_svg_from_upload' ) );
 			add_action( 'load-site-editor.php', array( $this, 'allow_svg_from_upload' ) );
 
+			// This filter runs very early on in the `wp_enqueue_media()` function, which is used to load the
+			// assets required to use the media JS APIs. Whilst we don't want to adjust the tabs, this does
+			// give us a good point to hook into _all_ the places allowing uploads and add SVGs to the list.
+			add_action(
+				'media_upload_tabs',
+				function ( $tabs ) {
+					$this->allow_svg_from_upload();
+
+					return $tabs;
+				}
+			);
+
 			// Init all the things.
 			add_action( 'init', array( $this, 'setup_blocks' ) );
 			add_filter( 'wp_handle_sideload_prefilter', array( $this, 'check_for_svg' ) );


### PR DESCRIPTION
### Description of the Change
This pull request introduces an additional hook to ensure SVG uploads are allowed in all relevant media upload contexts. The main change is the use of the `media_upload_tabs` action to call the `allow_svg_from_upload` method, ensuring SVG support is consistently applied across all upload interfaces.

Closes #240, #244 

### How to test the Change
* Add an image field to a settings page or a taxonomy term
* Try uploading an SVG
* It should be allowed

### Changelog Entry
* Added - The ability to upload SVGs from more admin locations.

### Credits
Props @darylldoyle 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
