### PR TITLE
add SVG support for Enable Media Replace

### DIFF
--- a/safe-svg.php
+++ b/safe-svg.php
@@ -133,6 +133,7 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 			add_action( 'load-post-new.php', array( $this, 'allow_svg_from_upload' ) );
 			add_action( 'load-post.php', array( $this, 'allow_svg_from_upload' ) );
 			add_action( 'load-site-editor.php', array( $this, 'allow_svg_from_upload' ) );
+			add_action( 'load-media_page_enable-media-replace/enable-media-replace', array( $this, 'allow_svg_from_upload' ) );
 
 			// This filter runs very early on in the `wp_enqueue_media()` function, which is used to load the
 			// assets required to use the media JS APIs. Whilst we don't want to adjust the tabs, this does


### PR DESCRIPTION
### Description of the Change
Provides SVG support for the Enable Media Replace plugin

Closes https://github.com/10up/safe-svg/issues/284

### How to test the Change

1. Install SafeSVG and Enable Media Replace
2. Upload an SVG
3. Attempt to replace the SVG with another one.
4. EMR will give a warning about the file type not being allowed. Hitting submit results in a fail message.
5. Once this PR is activated, the warnings will go away.

### Changelog Entry

Feature - Added support for Enable Media Replace plugin

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.

### Credits
@gthayer 
