### PR TITLE
Fix/svg mime type global registration

### DIFF
--- a/safe-svg.php
+++ b/safe-svg.php
@@ -149,10 +149,8 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 
 			// Init all the things.
 			add_action( 'init', array( $this, 'setup_blocks' ) );
-
-			// Register SVG MIME type globally for third-party plugin compatibility (e.g., WP Offload Media).
-			// This ensures wp_check_filetype() can identify SVG files in all contexts.
 			add_action( 'init', array( $this, 'register_svg_mime_type' ) );
+			add_filter( 'wp_check_filetype_and_ext', array( $this, 'fix_mime_type_svg' ), 100, 4 );
 			add_filter( 'wp_handle_sideload_prefilter', array( $this, 'check_for_svg' ) );
 			add_filter( 'wp_handle_upload_prefilter', array( $this, 'check_for_svg' ) );
 			add_filter( 'wp_prepare_attachment_for_js', array( $this, 'fix_admin_preview' ), 10, 3 );

--- a/safe-svg.php
+++ b/safe-svg.php
@@ -149,6 +149,10 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 
 			// Init all the things.
 			add_action( 'init', array( $this, 'setup_blocks' ) );
+
+			// Register SVG MIME type globally for third-party plugin compatibility (e.g., WP Offload Media).
+			// This ensures wp_check_filetype() can identify SVG files in all contexts.
+			add_action( 'init', array( $this, 'register_svg_mime_type' ) );
 			add_filter( 'wp_handle_sideload_prefilter', array( $this, 'check_for_svg' ) );
 			add_filter( 'wp_handle_upload_prefilter', array( $this, 'check_for_svg' ) );
 			add_filter( 'wp_prepare_attachment_for_js', array( $this, 'fix_admin_preview' ), 10, 3 );
@@ -171,6 +175,22 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 		public function allow_svg_from_upload() {
 			add_filter( 'upload_mimes', array( $this, 'allow_svg' ) );
 			add_filter( 'wp_check_filetype_and_ext', array( $this, 'fix_mime_type_svg' ), 75, 4 );
+		}
+
+		/**
+		 * Register SVG MIME type globally for proper detection by third-party plugins.
+		 *
+		 * This ensures wp_check_filetype() can identify SVG files in all contexts,
+		 * not just during specific admin page loads. This fixes compatibility with
+		 * plugins like WP Offload Media that process files outside of the standard
+		 * WordPress upload flow.
+		 *
+		 * @since 2.4.1
+		 *
+		 * @return void
+		 */
+		public function register_svg_mime_type() {
+			add_filter( 'upload_mimes', array( $this, 'allow_svg' ) );
 		}
 
 		/**


### PR DESCRIPTION
# Safe SVG PR Template (Issue #286)

### Description of the Change

**Problem:**
Safe SVG versions 2.2+ can be incompatible with WP Offload Media (and potentially other plugins that process media outside of standard WordPress admin page loads). When WP Offload Media attempts to offload SVG files to S3-compatible storage, it may fail with errors like:

- `AS3CF: Mime type "" is not allowed (Media Library Item with id XXX)`
- `ContentType must be a string... Found bool(false)`

**Root Cause:**
Safe SVG currently adds SVG MIME detection support contextually—during specific admin page loads (e.g. `load-upload.php`, `load-post.php`, `load-site-editor.php`, etc.) via `allow_svg_from_upload()`, which temporarily registers a `wp_check_filetype_and_ext` filter at priority 75, then removes it after upload processing completes.

When third-party plugins call `wp_check_filetype_and_ext()` outside of these contexts (e.g. WP Offload Media's background offload processing, cron jobs, REST API calls, CLI operations), Safe SVG's filter has been removed, causing MIME type detection for SVGs to return an empty type. This breaks downstream behavior that relies on a valid MIME type.

**Solution:**
Add a persistent `wp_check_filetype_and_ext` filter at priority 100 that ensures SVG MIME detection works in all contexts—including after Safe SVG's contextual priority-75 filter is removed during upload cleanup.

This change:
- Registers the filter once during `__construct()` and never removes it
- Uses priority 100 (higher than Safe SVG's existing priority 75) to avoid being removed by Safe SVG's `pre_move_uploaded_file` cleanup
- Ensures `wp_check_filetype_and_ext()` always returns `image/svg+xml` for `.svg` and `.svgz` files

**Why this is safe:**
- Does not change upload or sanitization behavior; `check_for_svg()` continues to sanitize during upload with capability checks
- Only affects MIME type *detection*—ensures third-party plugins can reliably identify SVG files
- Does not bypass any existing Safe SVG security/capability checks

**What WP Offload Media users still need to do:**
This fix ensures WordPress correctly identifies SVG MIME types. However, WP Offload Media maintains its own allowed MIME types list (defaulting to WordPress' `get_allowed_mime_types()`), which may not include SVG depending on your site configuration.

Users experiencing `AS3CF: Mime type "image/svg+xml" is not allowed` errors after applying this fix will need to add a filter to their theme or mu-plugin:

```php
add_filter( 'as3cf_allowed_mime_types', function( $types ) {
    $types['svg']  = 'image/svg+xml';
    $types['svgz'] = 'image/svg+xml';
    return $types;
}, 10, 1 );
```

This is expected behavior—WP Offload Media intentionally controls which file types are allowed for offload independent of WordPress upload capabilities, and this is outside Safe SVG's scope.

Closes #286

### How to test the Change

**Basic MIME detection test:**
```php
// Should always yield image/svg+xml with this fix
$filetype = wp_check_filetype_and_ext( '/path/to/test.svg', 'test.svg' );
var_dump( $filetype['type'] ); // string(13) "image/svg+xml"
```

**WP Offload Media integration test:**
1. Install Safe SVG (with this change) and WP Offload Media.
2. Configure WP Offload Media with an S3-compatible provider (AWS S3 / MinIO / DigitalOcean Spaces / etc.).
3. Enable "Copy to S3" in WP Offload Media.
4. Add the `as3cf_allowed_mime_types` filter (see "What WP Offload Media users still need to do" above).
5. Upload an SVG via the WordPress Media Library.
6. Verify the SVG offloads successfully (e.g. appears in the bucket and/or attachment metadata reflects offload).
7. Verify PNG/JPG continue to upload/offload normally.
8. Verify SVG upload permissions still work (users without capability cannot upload SVGs).

**Expected behavior without the `as3cf_allowed_mime_types` filter:**
- Upload succeeds and SVG appears in Media Library
- Offload fails with: `AS3CF: Mime type "image/svg+xml" is not allowed`
- (This is expected—WP Offload Media requires explicit allow-listing)

### Changelog Entry

> Fixed - SVG MIME type detection now works reliably in all contexts (including background processing, cron, REST API, CLI) by registering a persistent `wp_check_filetype_and_ext` filter. Improves compatibility with WP Offload Media and other plugins that process media outside standard admin page loads.

### Credits

Props @oneprince

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added Critical Flows / Test Cases / E2E Tests to cover my change.
- [x] All new and existing tests pass.
