### PR TITLE
Add global mime upload notes to readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ SVG Sanitization is done through the following library: [https://github.com/dary
 
 SVG Optimization is done through the following library: [https://github.com/svg/svgo](https://github.com/svg/svgo).
 
+### Technical: Upload Path Security
+
+WordPress’s `_wp_handle_upload( $file, $action )` function allows any `$action` value, which determines the filter hook name: `{$action}_prefilter`. Safe SVG hooks common actions like `wp_handle_upload` and `wp_handle_sideload`, but cannot hook arbitrary custom actions defined by third-party code. Since upload actions are unbounded and MIME allowances are global, we cannot guarantee sanitization coverage across all possible upload paths.
+
 ## Requirements
 
 * PHP 7.4+
@@ -67,6 +71,14 @@ add_filter( 'svg_allowed_tags', function ( $tags ) {
     return $tags;
 } );
 ```
+
+### Why doesn't Safe SVG globally enable SVG uploads?
+
+Safe SVG only allows SVGs through upload paths it can actively sanitize. While most WordPress uploads use standard functions like `wp_handle_upload()` (which Safe SVG hooks), plugins and themes can create custom upload paths by calling WordPress's underlying `_wp_handle_upload()` function with arbitrary action parameters.
+
+Globally enabling the `image/svg+xml` MIME type would allow SVGs through all upload paths—including custom ones Safe SVG cannot intercept and sanitize. This would create security vulnerabilities where unsanitized SVGs containing malicious scripts could be uploaded.
+
+This is a deliberate design decision: Safe SVG prioritizes guaranteed sanitization over broad compatibility. SVGs are only allowed when we can ensure they're safe.
 
 ### Where do I report security bugs found in this plugin?
 

--- a/readme.txt
+++ b/readme.txt
@@ -27,6 +27,10 @@ SVG Sanitization is done through the following library: [https://github.com/dary
 
 SVG Optimization is done through the following library: [https://github.com/svg/svgo](https://github.com/svg/svgo).
 
+= Technical: Upload Path Security =
+
+WordPress’s `_wp_handle_upload( $file, $action )` function allows any `$action` value, which determines the filter hook name: `{$action}_prefilter`. Safe SVG hooks common actions like `wp_handle_upload` and `wp_handle_sideload`, but cannot hook arbitrary custom actions defined by third-party code. Since upload actions are unbounded and MIME allowances are global, we cannot guarantee sanitization coverage across all possible upload paths.
+
 == Installation ==
 
 Install through the WordPress directory or download, unzip and upload the files to your `/wp-content/plugins/` directory
@@ -62,6 +66,14 @@ They take one argument that must be returned. See below for examples:
 
         return $tags;
     } );
+
+= Why doesn't Safe SVG globally enable SVG uploads? =
+
+Safe SVG only allows SVGs through upload paths it can actively sanitize. While most WordPress uploads use standard functions like `wp_handle_upload()` (which Safe SVG hooks), plugins and themes can create custom upload paths by calling WordPress's underlying `_wp_handle_upload()` function with arbitrary action parameters.
+
+Globally enabling the `image/svg+xml` MIME type would allow SVGs through all upload paths—including custom ones Safe SVG cannot intercept and sanitize. This would create security vulnerabilities where unsanitized SVGs containing malicious scripts could be uploaded.
+
+This is a deliberate design decision: Safe SVG prioritizes guaranteed sanitization over broad compatibility. SVGs are only allowed when we can ensure they're safe.
 
 = Where do I report security bugs found in this plugin? =
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This pull request updates the documentation in both `README.md` and `readme.txt` to clarify the security considerations around SVG upload handling in WordPress. The new sections explain why Safe SVG does not globally enable SVG uploads and detail the limitations imposed by WordPress’s upload API, emphasizing the plugin’s focus on security over broad compatibility.

**Documentation updates regarding SVG upload security:**

- Added a "Technical: Upload Path Security" section to both `README.md` and `readme.txt`, explaining that WordPress’s `_wp_handle_upload()` function allows arbitrary actions, making it impossible for Safe SVG to guarantee sanitization across all upload paths. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R28-R31) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R30-R33)
- Added a "Why doesn't Safe SVG globally enable SVG uploads?" section to both documentation files, describing the risks of globally enabling SVG uploads and reinforcing the plugin’s design decision to only allow SVGs through upload paths it can actively sanitize. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R75-R82) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R70-R77)

Relates to #286, #296.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Developer - Added docs on recommendation against globally enabling SVG MIME types. 

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @darylldoyle, @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
